### PR TITLE
feat: support aten::matmul with different input shape

### DIFF
--- a/core/conversion/converters/impl/matrix_multiply.cpp
+++ b/core/conversion/converters/impl/matrix_multiply.cpp
@@ -12,18 +12,45 @@ auto mm_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns().pattern(
     {"aten::matmul(Tensor self, Tensor other) -> (Tensor)",
      [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
        auto self = args[0].ITensorOrFreeze(ctx);
+       auto in_shape = util::toVec(self->getDimensions());
        LOG_DEBUG("self tensor shape: " << self->getDimensions());
 
        auto other = args[1].ITensorOrFreeze(ctx);
+       auto other_shape = util::toVec(other->getDimensions());
        LOG_DEBUG("other tensor shape: " << other->getDimensions());
 
-       auto mm_layer = ctx->net->addMatrixMultiply(
-           *self, nvinfer1::MatrixOperation::kNONE, *other, nvinfer1::MatrixOperation::kNONE);
-       TRTORCH_CHECK(mm_layer, "Unable to create matrix multiplication node: " << *n);
-       mm_layer->setName(util::node_info(n).c_str());
-       auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], mm_layer->getOutput(0));
+       // add support when self dims != other dims
+       if (in_shape.size() != other_shape.size() && in_shape.size() > 2) {
+         auto shuffle = ctx->net->addShuffle(*self);
+         std::vector<int64_t> new_shape;
+         int val = 1;
+         for (int i = 0; i < (int)in_shape.size() - 1; i++) {
+           val = val * in_shape[i];
+         }
+         new_shape.push_back(val);
+         new_shape.push_back(in_shape[in_shape.size() - 1]);
+         shuffle->setReshapeDimensions(util::toDims(new_shape));
+         auto mm_layer = ctx->net->addMatrixMultiply(
+             *shuffle->getOutput(0), nvinfer1::MatrixOperation::kNONE, *other, nvinfer1::MatrixOperation::kNONE);
+         mm_layer->setName(util::node_info(n).c_str());
+         std::vector<int64_t> out_shape;
+         for (int i = 0; i < (int)in_shape.size() - 1; i++) {
+           out_shape.push_back(in_shape[i]);
+         }
+         out_shape.push_back(other_shape[other_shape.size() - 1]);
+         auto out_shuffle = ctx->net->addShuffle(*mm_layer->getOutput(0));
+         out_shuffle->setReshapeDimensions(util::toDims(out_shape));
+         auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], out_shuffle->getOutput(0));
+         LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+       } else {
+         auto mm_layer = ctx->net->addMatrixMultiply(
+             *self, nvinfer1::MatrixOperation::kNONE, *other, nvinfer1::MatrixOperation::kNONE);
+         TRTORCH_CHECK(mm_layer, "Unable to create matrix multiplication node: " << *n);
+         mm_layer->setName(util::node_info(n).c_str());
+         auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], mm_layer->getOutput(0));
+         LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+       }
 
-       LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
        return true;
      }});
 } // namespace

--- a/core/conversion/converters/impl/matrix_multiply.cpp
+++ b/core/conversion/converters/impl/matrix_multiply.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "core/conversion/converters/converters.h"
 #include "core/util/prelude.h"
 
@@ -18,29 +19,31 @@ auto mm_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns().pattern(
        auto other = args[1].ITensorOrFreeze(ctx);
        auto other_shape = util::toVec(other->getDimensions());
        LOG_DEBUG("other tensor shape: " << other->getDimensions());
-
+       int max_dim = std::max(in_shape.size(), other_shape.size());
+       int min_dim = std::min(in_shape.size(), other_shape.size());
        // add support when self dims != other dims
-       if (in_shape.size() != other_shape.size() && in_shape.size() > 2) {
-         auto shuffle = ctx->net->addShuffle(*self);
+       if (in_shape.size() != other_shape.size()) {
+         auto org_tensor = in_shape.size() > other_shape.size() ? other : self;
+         auto shuffle = ctx->net->addShuffle(*org_tensor);
+
+         int diff_dim = max_dim - min_dim;
+         auto old_shape = in_shape.size() > other_shape.size() ? other_shape : in_shape;
          std::vector<int64_t> new_shape;
-         int val = 1;
-         for (int i = 0; i < (int)in_shape.size() - 1; i++) {
-           val = val * in_shape[i];
+         for (int i = 0; i < diff_dim; i++) {
+           new_shape.push_back(1);
          }
-         new_shape.push_back(val);
-         new_shape.push_back(in_shape[in_shape.size() - 1]);
+         for (int i = 0; i < min_dim; i++) {
+           new_shape.push_back(old_shape[i]);
+         }
          shuffle->setReshapeDimensions(util::toDims(new_shape));
+         auto reshaped_tensor = shuffle->getOutput(0);
+         auto new_self = in_shape.size() > other_shape.size() ? self : reshaped_tensor;
+         auto new_other = other_shape.size() > in_shape.size() ? other : reshaped_tensor;
          auto mm_layer = ctx->net->addMatrixMultiply(
-             *shuffle->getOutput(0), nvinfer1::MatrixOperation::kNONE, *other, nvinfer1::MatrixOperation::kNONE);
+             *new_self, nvinfer1::MatrixOperation::kNONE, *new_other, nvinfer1::MatrixOperation::kNONE);
          mm_layer->setName(util::node_info(n).c_str());
-         std::vector<int64_t> out_shape;
-         for (int i = 0; i < (int)in_shape.size() - 1; i++) {
-           out_shape.push_back(in_shape[i]);
-         }
-         out_shape.push_back(other_shape[other_shape.size() - 1]);
-         auto out_shuffle = ctx->net->addShuffle(*mm_layer->getOutput(0));
-         out_shuffle->setReshapeDimensions(util::toDims(out_shape));
-         auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], out_shuffle->getOutput(0));
+
+         auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], mm_layer->getOutput(0));
          LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
        } else {
          auto mm_layer = ctx->net->addMatrixMultiply(

--- a/tests/core/conversion/converters/test_matrix_multiply.cpp
+++ b/tests/core/conversion/converters/test_matrix_multiply.cpp
@@ -25,3 +25,45 @@ TEST(Converters, ATenMMConvertsCorrectly) {
 
   ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
 }
+
+TEST(Converters, ATenMMND1ConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %1 : Tensor):
+        %2 : Tensor = aten::matmul(%0, %1)
+        return (%2))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in1 = at::randint(0, 5, {3, 2, 3}, {at::kCUDA});
+  auto in2 = at::randint(0, 5, {3, 3}, {at::kCUDA});
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in1, in2});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in1, in2});
+  auto trt = trt_results[0].reshape_as(jit_results[0]);
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenMMND2ConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %1 : Tensor):
+        %2 : Tensor = aten::matmul(%0, %1)
+        return (%2))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in1 = at::randint(0, 5, {3, 2, 3}, {at::kCUDA});
+  auto in2 = at::randint(0, 5, {3, 3, 3}, {at::kCUDA});
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in1, in2});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in1, in2});
+  auto trt = trt_results[0].reshape_as(jit_results[0]);
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.


- New feature (non-breaking change which adds functionality)
support aten::matmul with diiferent input shape, like [1,32,64] * [64, 64]

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes