### PR TITLE
fix: support c10::List type of output in MarkOutputs

### DIFF
--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -173,6 +173,20 @@ void AddInputs(ConversionCtx* ctx, at::ArrayRef<const torch::jit::Value*> inputs
   }
 #endif
 }
+void MarkOutputsOfIvalue(ConversionCtx* ctx, c10::IValue out_ivalue, const torch::jit::Value* out) {
+  if (out_ivalue.isCustomClass()) {
+    std::string name = std::string("output_") + std::to_string(ctx->num_outputs);
+    auto output_container = out_ivalue.toCustomClass<TensorContainer>();
+    nvinfer1::ITensor* out_tensor = output_container.get()->tensor();
+    out_tensor->setName(name.c_str());
+    ctx->net->markOutput(*out_tensor);
+    LOG_INFO(
+        ctx->logger, "Marking Output " << out->debugName() << " named " << name << " in engine (ctx.MarkOutput)");
+    ctx->num_outputs += 1;
+  } else {
+    TRTORCH_THROW_ERROR("Unknown output type. Only a single tensor or a TensorList type is supported.");
+  }
+}
 
 void MarkOutputs(ConversionCtx* ctx, at::ArrayRef<const torch::jit::Value*> outputs) {
   for (auto out : outputs) {
@@ -180,17 +194,13 @@ void MarkOutputs(ConversionCtx* ctx, at::ArrayRef<const torch::jit::Value*> outp
     if (it == ctx->value_tensor_map.end()) {
       if (ctx->evaluated_value_map.find(out) != ctx->evaluated_value_map.end()) {
         auto out_ivalue = ctx->evaluated_value_map[out];
-        if (out_ivalue.isCustomClass()) {
-          std::string name = std::string("output_") + std::to_string(ctx->num_outputs);
-          auto output_container = out_ivalue.toCustomClass<TensorContainer>();
-          nvinfer1::ITensor* out_tensor = output_container.get()->tensor();
-          out_tensor->setName(name.c_str());
-          ctx->net->markOutput(*out_tensor);
-          LOG_INFO(
-              ctx->logger, "Marking Output " << out->debugName() << " named " << name << " in engine (ctx.MarkOutput)");
-          ctx->num_outputs += 1;
+        if (out_ivalue.isList()) {
+          c10::List<c10::IValue> value_list = out_ivalue.toList();
+          for(auto it = value_list.begin(); it != value_list.end(); it++) {
+            MarkOutputsOfIvalue(ctx, *it, out);
+          }
         } else {
-          TRTORCH_THROW_ERROR("Unknown output type. Only a single tensor or a TensorList type is supported.");
+           MarkOutputsOfIvalue(ctx, out_ivalue, out);
         }
       }
     } else {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
Support c10::List<c10::IValue> type of output type in **void MarkOutputs(ConversionCtx* ctx, at::ArrayRef<const torch::jit::Value*> outputs)**

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes