### PR TITLE
fix converter aten::slice.Tensor when use dynamic shape

### DIFF
--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -224,6 +224,14 @@ auto select_registrations TRTORCH_UNUSED =
                auto end = (endIdx < 0) ? (maxDim + endIdx) : endIdx;
                auto step = args[4].unwrapToInt();
 
+               if (startIdxIVal->isNone() && endIdxIVal->isNone()) { // for dynamic shape
+                 auto layer = ctx->net->addIdentity(*in);
+                 layer->setOutputType(0, in->getType());
+                 auto out = ctx->AssociateValueAndTensor(n->outputs()[0], layer->getOutput(0));
+                 LOG_DEBUG("Slice layer output shape: " << out->getDimensions());
+                 return true;
+               }
+
                LOG_DEBUG("Start idx: " << start);
                LOG_DEBUG("End idx: " << end);
 


### PR DESCRIPTION
Signed-off-by: seventh <xuweiqi117@gmail.com>

# Description
support converter when I split tensor with dynamic shape
example :
tensor.shape is [-1, 4, -1, -1]
output = tensor[:, -1:]
it will call twice converter aten::slice.Tensor. it worked for default arguments[:]
Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes