### PR TITLE
fix(//py): Constrain the CUDA version in container builds

### DIFF
--- a/py/build_whl.sh
+++ b/py/build_whl.sh
@@ -5,6 +5,7 @@
 cd /workspace/Torch-TensorRT/py
 
 export CXX=g++
+export CUDA_HOME=/usr/local/cuda-11.3
 
 build_py36() {
     /opt/python/cp36-cp36m/bin/python -m pip install -r requirements.txt


### PR DESCRIPTION
# Description

Theres two versions of CUDA in the build container so we need to explicitly pick the right one.

Fixes #697 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes