### PR TITLE
feat: support aten::extend evaluator

### DIFF
--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -398,7 +398,7 @@ void ConvertBlockToNetDef(
       EvaluateConditionalBlock(ctx, n);
     } else if (to_eval) {
       auto eval = EvaluateNode(ctx, n);
-      if (eval) {
+      if (eval && n->outputs().size() > 0) {
         if (n->outputs().size() > 1) { // For ListUnpack scenario
           if (eval.value().isTuple()) {
             auto eval_list = eval.value().toTuple();

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -295,6 +295,7 @@ auto aten_registrations TORCHTRT_UNUSED =
                         for (int64_t i = 0; i < other_size; i++) {
                           self.push_back(other.get(i));
                         }
+                        return self;
                       } else {
                         TORCHTRT_THROW_ERROR(
                             "Unimplemented data type for aten::extend.t evaluator: "

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -302,6 +302,32 @@ TEST(Evaluators, FloorFloatIntEvaluatesCorrectly) {
   ASSERT_TRUE(jit_results[0] == trt_results[0]);
 }
 
+TEST(Evaluators, ATenExtendEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %1 : Tensor):
+        %2 : int = prim::Constant[value=0]()
+        %3 : Tensor[] = prim::ListConstruct(%0)
+        %4 : Tensor[] = prim::ListConstruct(%1)
+        aten::extend(%3, %4)
+        %5 : Tensor = aten::cat(%3, %2)
+        return (%5))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in0 = at::randint(1, 10, {3, 4}, {at::kCUDA});
+  auto in1 = at::randint(1, 10, {5, 4}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in0, in1});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in0, in1});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
 TEST(Evaluators, ATenAppendWithITensorEvaluatesCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor, %1 : Tensor):


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

Support aten::extend evaluator. The Function schema is `"aten::extend.t(t[](a!) self, t[] other) -> ()"`

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes