### PR TITLE
fix: Guard test activation for CI testing

### DIFF
--- a/tests/core/conversion/converters/test_activation.cpp
+++ b/tests/core/conversion/converters/test_activation.cpp
@@ -200,6 +200,7 @@ TEST(Converters, ATenEluConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
+#ifndef DISABLE_TEST_IN_CI
 TEST(Converters, ATenGELUConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor):
@@ -225,3 +226,4 @@ TEST(Converters, ATenGELUConvertsCorrectly) {
 
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 5e-2));
 }
+#endif


### PR DESCRIPTION
Signed-off-by: Anurag Dixit <anuragd@nvidia.com>

# Description
Aligning the CI testing guard for test_activation unit test case. This will make sure that the test suite is consistent across different release guarded by CI.

Fixes # (issue)

## Type of change
Non-Breaking change
Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes