### PR TITLE
fix: python test_api change for scripted_modules

### DIFF
--- a/core/conversion/evaluators/eval_util.cpp
+++ b/core/conversion/evaluators/eval_util.cpp
@@ -238,7 +238,7 @@ at::Tensor createTensorFromList(
   /// Gets shape of tensor to be created
   auto sizes = compute_sizes(data);
   checkListInputType(elem_type, sizes.size() == 1 && sizes[0] == 0);
-  at::ScalarType initial_scalar_type = c10::scalarTypeFromJitType(elem_type);
+  at::ScalarType initial_scalar_type = c10::scalarTypeFromJitType(*elem_type);
   if (initial_scalar_type == at::ScalarType::Double) {
     initial_scalar_type = at::typeMetaToScalarType(c10::get_default_dtype());
   }

--- a/tests/py/test_api.py
+++ b/tests/py/test_api.py
@@ -30,12 +30,13 @@ class TestCompile(ModelTestCase):
         self.assertTrue(same < 2e-2)
 
     def test_compile_script(self):
-        trt_mod = torchtrt.ts.compile(self.scripted_model,
+        with torch.no_grad():
+            trt_mod = torchtrt.ts.compile(self.scripted_model,
                                       inputs=[self.input],
                                       device=torchtrt.Device(gpu_id=0),
                                       enabled_precisions={torch.float})
-        same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
-        self.assertTrue(same < 2e-2)
+            same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
+            self.assertTrue(same < 2e-2)
 
     def test_compile_global(self):
         trt_mod = torchtrt.compile(self.scripted_model,
@@ -46,12 +47,13 @@ class TestCompile(ModelTestCase):
         self.assertTrue(same < 2e-2)
 
     def test_compile_global_nn_mod(self):
-        trt_mod = torchtrt.compile(self.model,
+        with torch.no_grad():
+            trt_mod = torchtrt.compile(self.model,
                                    inputs=[self.input],
                                    device=torchtrt.Device(gpu_id=0),
                                    enabled_precisions={torch.float})
-        same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
-        self.assertTrue(same < 2e-2)
+            same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
+            self.assertTrue(same < 2e-2)
 
     def test_from_torch_tensor(self):
         compile_spec = {


### PR DESCRIPTION
# Description
This change is a workaround for python api_test with scripted module. It works with recent torch APIs

Fixes # (issue)
## Type of change
Non-Breaking change.

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes