### PR TITLE
feat: replace aten::view with aten::reshape during lowering

### DIFF
--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -45,6 +45,7 @@ void LowerGraph(std::shared_ptr<torch::jit::Graph>& g, LowerInfo lower_info) {
   passes::ReduceToOperation(g);
   passes::ReduceGelu(g);
   passes::RemoveContiguous(g);
+  passes::ViewToReshape(g);
   passes::RemoveDropout(g);
   passes::LinearToAddMM(g);
   passes::Conv1DToConvolution(g);

--- a/core/lowering/passes/BUILD
+++ b/core/lowering/passes/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "reduce_gelu.cpp",
         "remove_bn_dim_check.cpp",
         "remove_contiguous.cpp",
+        "view_to_reshape.cpp",
         "remove_dropout.cpp",
         "remove_nops.cpp",
         "silu_to_sigmoid_multiplication.cpp",

--- a/core/lowering/passes/passes.h
+++ b/core/lowering/passes/passes.h
@@ -24,6 +24,7 @@ void ReduceGelu(std::shared_ptr<torch::jit::Graph>& graph);
 void MarkNodesForFallback(std::shared_ptr<torch::jit::Graph>& g, bool delete_delims);
 void RemoveBNDimCheck(std::shared_ptr<torch::jit::Graph> graph);
 void RemoveContiguous(std::shared_ptr<torch::jit::Graph>& graph);
+void ViewToReshape(std::shared_ptr<torch::jit::Graph>& graph);
 void RemoveDropout(std::shared_ptr<torch::jit::Graph>& graph);
 void RemoveNOPs(std::shared_ptr<torch::jit::Graph> graph);
 void UnpackAddMM(std::shared_ptr<torch::jit::Graph>& graph);

--- a/core/lowering/passes/view_to_reshape.cpp
+++ b/core/lowering/passes/view_to_reshape.cpp
@@ -1,0 +1,31 @@
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include "core/util/prelude.h"
+
+namespace torch_tensorrt {
+namespace core {
+namespace lowering {
+namespace passes {
+
+void ViewToReshape(std::shared_ptr<torch::jit::Graph>& graph) {
+  std::string view_pattern = R"IR(
+        graph(%x, %1):
+            %out : Tensor = aten::view(%x, %1)
+            return (%out))IR";
+
+  std::string reshape_pattern = R"IR(
+        graph(%x, %1):
+            %out : Tensor = aten::reshape(%x, %1)
+            return (%out))IR";
+
+  // replace aten::view with aten::reshape
+  torch::jit::SubgraphRewriter map_view_to_reshape;
+  map_view_to_reshape.RegisterRewritePattern(view_pattern, reshape_pattern);
+  map_view_to_reshape.runOnGraph(graph);
+
+  LOG_GRAPH("Post lowering of aten::view -> " << *graph);
+}
+
+} // namespace passes
+} // namespace lowering
+} // namespace core
+} // namespace torch_tensorrt

--- a/tests/core/lowering/BUILD
+++ b/tests/core/lowering/BUILD
@@ -51,6 +51,10 @@ lowering_test(
 )
 
 lowering_test(
+    name = "test_view_to_reshape_pass",
+)
+
+lowering_test(
     name = "test_operator_aliasing_pass",
 )
 
@@ -75,6 +79,7 @@ test_suite(
         ":test_operator_aliasing_pass",
         ":test_remove_contiguous_pass",
         ":test_remove_detach_pass",
+        ":test_view_to_reshape_pass",
         ":test_remove_dropout_pass",
         ":test_reduce_to_pass",
         ":test_reduce_gelu",

--- a/tests/core/lowering/test_view_to_reshape_pass.cpp
+++ b/tests/core/lowering/test_view_to_reshape_pass.cpp
@@ -33,3 +33,60 @@ TEST(LoweringPasses, ViewToReshapeCorrectly) {
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }
+
+TEST(LoweringPasses, ViewToReshapeResultsCorrectly) {
+  std::string graph = R"IR(
+    graph(%x.1 : Tensor):
+        %1 : int = prim::Constant[value=0]() 
+        %2 : int[] = prim::Constant[value=[1, 0, 3, 2]]()
+        %5 : int = prim::Constant[value=0]() 
+        %p.1 : Tensor = aten::permute(%x.1, %2)
+        %28 : int = prim::Constant[value=1]()
+        %29 : int = prim::Constant[value=2]()
+        %30 : int = prim::Constant[value=3]()
+        %31 : int = prim::Constant[value=-1]()
+        %size.1 : int[] = aten::size(%x.1) 
+        %33 : int = aten::__getitem__(%size.1, %5) 
+        %34 : int = aten::__getitem__(%size.1, %28)
+        %35 : int = aten::mul(%33, %34) 
+        %36 : int = aten::__getitem__(%size.1, %29) 
+        %37 : int = aten::__getitem__(%size.1, %30)  
+        %38 : int = aten::mul(%36, %37) 
+        %39 : int[] = prim::ListConstruct(%31, %35, %38)
+        %c : Tensor = aten::contiguous(%p.1, %1)
+        %v.1 : Tensor = aten::view(%c, %39) 
+        return (%v.1))IR";
+
+  torch_tensorrt::core::util::logging::get_logger().set_reportable_log_level(
+      torch_tensorrt::core::util::logging::LogLevel::kDEBUG);
+
+  auto parsed_g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, parsed_g.get());
+
+  std::vector<torch_tensorrt::core::ir::Input> inputs;
+  inputs.push_back(torch_tensorrt::core::ir::Input({2, 3, 4, 5}));
+  torch_tensorrt::core::CompileSpec cfg(inputs);
+  cfg.partition_info.enabled = true;
+  cfg.partition_info.forced_fallback_operators.push_back("aten::permute");
+
+  torch::jit::script::Module mod(c10::QualifiedName("module"));
+
+  auto self = parsed_g->insertInput(0, "self_1");
+  self->setType(mod.type());
+  auto cur_method = mod._ivalue()->compilation_unit()->create_function(c10::QualifiedName("forward"), parsed_g);
+  auto schema = torch_tensorrt::core::util::GenerateGraphSchema(cur_method->name(), parsed_g);
+  mod.type()->addMethod(cur_method);
+  cur_method->setSchema(schema);
+
+  torch::jit::script::Module new_mod = torch_tensorrt::core::CompileGraph(mod, cfg);
+
+  auto in = at::randint(5, {2, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto trt_in = at::clone(in);
+
+  auto jit_results = mod.forward({jit_in});
+  auto trt_results = new_mod.forward({trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results.toTensor(), trt_results.toTensor(), 2e-6));
+}

--- a/tests/core/lowering/test_view_to_reshape_pass.cpp
+++ b/tests/core/lowering/test_view_to_reshape_pass.cpp
@@ -1,0 +1,35 @@
+#include <string>
+#include "core/compiler.h"
+#include "core/lowering/passes/passes.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "torch/csrc/jit/ir/subgraph_matcher.h"
+
+TEST(LoweringPasses, ViewToReshapeCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x : Tensor, %1, %1.1):
+        %0 : int = prim::Constant[value=0]()
+        %2 : Tensor = aten::permute(%x, %1)
+        %3 : Tensor = aten::contiguous(%2, %0)
+        %4 : Tensor = aten::view(%3, %1.1)
+        return (%4))IR";
+  std::string target_graph = R"IR(
+    graph(%x : Tensor, %1, %1.1):
+        %0 : int = prim::Constant[value=0]()
+        %2 : Tensor = aten::permute(%x, %1)
+        %4 : Tensor = aten::reshape(%2, %1.1)
+        return (%4))IR";
+
+  torch_tensorrt::core::util::logging::get_logger().set_reportable_log_level(
+      torch_tensorrt::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+  torch_tensorrt::core::lowering::passes::RemoveContiguous(sg);
+  torch_tensorrt::core::lowering::passes::ViewToReshape(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

During lowering, I replace `aten::view` with `aten::reshape`. According to the [document](https://pytorch.org/docs/stable/generated/torch.reshape.html?highlight=reshape#torch.reshape), the `aten::reshape`'s input can be contiguous or not. During the shape analysis process, even if the `aten::reshape` input is the output of `aten::permute` it works.

Fixes #742 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes