### PR TITLE
fix : fix a bug in resolveNonTensorInputs that if the segment that pr…

### DIFF
--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -176,7 +176,7 @@ void resolveNonTensorInputs(PartitionedGraph& segmented_blocks) { // , std::shar
     // if the segment that produce this nonTensor value is kTensorRT but consumed in kTorch, inject nodes in the first
     // kTorch segment.
     if (segmented_blocks[use_info.produce_id].target() == SegmentedBlock::kTensorRT && !use_info.torch_use_id.empty()) {
-      auto first_torch_id = use_info.torch_use_id.front();
+      auto first_torch_id = use_info.torch_use_id.back();
       if (!updated_segments.count(first_torch_id)) {
         // Segmented Blocks with non-tensor inputs will have to be re-segmented as
         // Torch-TensorRT doesn't support non-tensor inputs for a module.

--- a/tests/core/partitioning/BUILD
+++ b/tests/core/partitioning/BUILD
@@ -32,6 +32,10 @@ partitioning_test(
   name = "test_stitched_graph",
 )
 
+partitioning_test(
+  name = "test_resolve_nontensor_inputs",
+)
+
 cc_test(
   name = "test_fallback_graph_output",
   srcs = ["test_fallback_graph_output.cpp"],
@@ -86,6 +90,7 @@ test_suite(
         ":test_stitched_graph",
         ":test_fallback_graph_output",
         ":test_loop_fallback",
-        ":test_conditionals"
+        ":test_conditionals",
+        ":test_resolve_nontensor_inputs"
     ]
 )

--- a/tests/core/partitioning/test_resolve_nontensor_inputs.cpp
+++ b/tests/core/partitioning/test_resolve_nontensor_inputs.cpp
@@ -1,0 +1,70 @@
+#include <string>
+#include "core/compiler.h"
+#include "core/util/trt_util.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "torch/script.h"
+
+TEST(Partitioning, ResolveNonTensorInputsCorrectly) {
+  const auto graph = R"IR(
+        graph(%x : Tensor, %y : Tensor):
+          %0 : int = prim::Constant[value=0]()
+          %1 : int = prim::Constant[value=1]()
+          %a : Tensor = aten::add(%x, %y, %1)
+          %s : int = aten::size(%a, %1)
+          %D3.1 : Tensor = prim::NumToTensor(%s)
+          %19 : bool = aten::is_floating_point(%D3.1)
+          %2 : Tensor = prim::If(%19)
+            block0():
+                %2.1 : Tensor = aten::sub(%a, %y, %1)
+                -> (%2.1)
+            block1():
+                %2.2 : Tensor = aten::sub(%a, %y, %0)
+                -> (%2.2)
+          %3 : Tensor = prim::If(%19)
+            block0():
+                %3.1 : Tensor = aten::sub(%a, %y, %1)
+                -> (%3.1)
+            block1():
+                %3.2 : Tensor = aten::sub(%a, %y, %0)
+                -> (%3.2)
+          %4 : Tensor = aten::add(%2, %3, %1)
+          return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  std::vector<torch_tensorrt::core::ir::Input> inputs;
+  inputs.push_back(torch_tensorrt::core::ir::Input({3, 4}));
+  inputs.push_back(torch_tensorrt::core::ir::Input({3, 4}));
+  torch_tensorrt::core::CompileSpec cfg(inputs);
+  cfg.partition_info.enabled = true;
+  cfg.partition_info.forced_fallback_operators.push_back("aten::sub");
+  cfg.convert_info.engine_settings.truncate_long_and_double = true;
+  cfg.partition_info.truncate_long_and_double = true;
+
+  torch::jit::script::Module mod(c10::QualifiedName("module"));
+
+  auto self = g->insertInput(0, "self_1");
+  self->setType(mod.type());
+  auto cur_method = mod._ivalue()->compilation_unit()->create_function(c10::QualifiedName("forward"), g);
+  auto schema = torch_tensorrt::core::util::GenerateGraphSchema(cur_method->name(), g);
+  mod.type()->addMethod(cur_method);
+  cur_method->setSchema(schema);
+
+  torch::jit::script::Module new_mod = torch_tensorrt::core::CompileGraph(mod, cfg);
+
+  auto in0 = at::randint(5, {3, 4}, {at::kCUDA});
+  auto in1 = at::randint(5, {3, 4}, {at::kCUDA});
+
+  auto jit_in0 = at::clone(in0);
+  auto jit_in1 = at::clone(in1);
+  auto trt_in0 = at::clone(in0);
+  auto trt_in1 = at::clone(in1);
+
+  auto jit_results = mod.forward({jit_in0, jit_in1});
+  auto trt_results = new_mod.forward({trt_in0, trt_in1});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results.toTensor(), trt_results.toTensor(), 2e-6));
+}


### PR DESCRIPTION
…oduce this nonTensor value is kTensorRT but consumed in kTorch, inject nodes in the first kTorch segment.

Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description
Fix a bug in resolveNonTensorInputs that if the segment that produce this nonTensor value is kTensorRT but consumed in kTorch, inject nodes in the first kTorch segment.

Fixes #756 

## Type of change

Please delete options that are not relevant and/or add your own.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes