### PR TITLE
refactor: Added a py lint to address PR failures

### DIFF
--- a/tests/py/test_api.py
+++ b/tests/py/test_api.py
@@ -32,9 +32,9 @@ class TestCompile(ModelTestCase):
     def test_compile_script(self):
         with torch.no_grad():
             trt_mod = torchtrt.ts.compile(self.scripted_model,
-                                      inputs=[self.input],
-                                      device=torchtrt.Device(gpu_id=0),
-                                      enabled_precisions={torch.float})
+                                          inputs=[self.input],
+                                          device=torchtrt.Device(gpu_id=0),
+                                          enabled_precisions={torch.float})
             same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
             self.assertTrue(same < 2e-2)
 
@@ -49,9 +49,9 @@ class TestCompile(ModelTestCase):
     def test_compile_global_nn_mod(self):
         with torch.no_grad():
             trt_mod = torchtrt.compile(self.model,
-                                   inputs=[self.input],
-                                   device=torchtrt.Device(gpu_id=0),
-                                   enabled_precisions={torch.float})
+                                       inputs=[self.input],
+                                       device=torchtrt.Device(gpu_id=0),
+                                       enabled_precisions={torch.float})
             same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
             self.assertTrue(same < 2e-2)
 


### PR DESCRIPTION
Signed-off-by: Anurag Dixit <anuragd@nvidia.com>

# Description
Currently, different PRs are reporting failures for linting. Fixing this in NGC branch.
Analogous to PR [753](https://github.com/NVIDIA/Torch-TensorRT/pull/753)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes