### PR TITLE
Feat: support aten::adaptive_max_pool1d, aten::adaptive_avg_pool3d and aten::adaptive_max_pool3d operators and fix issue #791

### DIFF
--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -37,7 +37,8 @@ bool AdaptivePoolingConverter(
     ConversionCtx* ctx,
     const torch::jit::Node* n,
     args& args,
-    nvinfer1::PoolingType pool_type, const std::string& mode) {
+    nvinfer1::PoolingType pool_type,
+    const std::string& mode) {
   auto in = args[0].ITensorOrFreeze(ctx);
   auto out_size = util::toDims(args[1].unwrapToIntList());
 
@@ -226,15 +227,30 @@ auto pooling_registrations TORCHTRT_UNUSED =
              }})
         .pattern({"aten::adaptive_avg_pool1d(Tensor self, int[1] output_size) -> (Tensor)",
                   [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                    return AdaptivePoolingConverter(ctx, n, args, nvinfer1::PoolingType::kAVERAGE, "adaptive_avg_pool1d");
+                    return AdaptivePoolingConverter(
+                        ctx, n, args, nvinfer1::PoolingType::kAVERAGE, "adaptive_avg_pool1d");
+                  }})
+        .pattern({"aten::adaptive_max_pool1d(Tensor self, int[2] output_size) -> (Tensor, Tensor)",
+                  [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+                    return AdaptivePoolingConverter(ctx, n, args, nvinfer1::PoolingType::kMAX, "adaptive_max_pool1d");
                   }})
         .pattern({"aten::adaptive_avg_pool2d(Tensor self, int[2] output_size) -> (Tensor)",
                   [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                    return AdaptivePoolingConverter(ctx, n, args, nvinfer1::PoolingType::kAVERAGE, "adaptive_avg_pool2d");
+                    return AdaptivePoolingConverter(
+                        ctx, n, args, nvinfer1::PoolingType::kAVERAGE, "adaptive_avg_pool2d");
                   }})
         .pattern({"aten::adaptive_max_pool2d(Tensor self, int[2] output_size) -> (Tensor, Tensor)",
                   [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
                     return AdaptivePoolingConverter(ctx, n, args, nvinfer1::PoolingType::kMAX, "adaptive_max_pool2d");
+                  }})
+        .pattern({"aten::adaptive_avg_pool3d(Tensor self, int[3] output_size) -> (Tensor)",
+                  [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+                    return AdaptivePoolingConverter(
+                        ctx, n, args, nvinfer1::PoolingType::kAVERAGE, "adaptive_avg_pool3d");
+                  }})
+        .pattern({"aten::adaptive_max_pool3d(Tensor self, int[3] output_size) -> (Tensor, Tensor)",
+                  [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+                    return AdaptivePoolingConverter(ctx, n, args, nvinfer1::PoolingType::kMAX, "adaptive_max_pool3d");
                   }});
 } // namespace
 } // namespace impl

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -16,8 +16,9 @@ bool GlobalPoolingConverter(
     nvinfer1::PoolingType pool_type) {
   auto in = args[0].ITensorOrFreeze(ctx);
   nvinfer1::Dims dims = in->getDimensions();
+  auto out_size = util::toDims(args[1].unwrapToIntList());
   // Generate a bitmask of all 1s except the last 2 bits (N and C axes)
-  uint32_t reduceAxes = ((1 << dims.nbDims) - 1) & ~0b11;
+  uint32_t reduceAxes = ((1 << dims.nbDims) - 1) ^ ((1 << (dims.nbDims - out_size.nbDims)) - 1);
   auto* new_layer = ctx->net->addReduce(
       *in,
       pool_type == nvinfer1::PoolingType::kMAX ? nvinfer1::ReduceOperation::kMAX : nvinfer1::ReduceOperation::kAVG,

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -16,7 +16,7 @@ bool GlobalPoolingConverter(
     nvinfer1::PoolingType pool_type) {
   auto in = args[0].ITensorOrFreeze(ctx);
   nvinfer1::Dims dims = in->getDimensions();
-  // Generate a bitmask of all 1s except the last 2 bits (N and C axes) when dims.nbDims >= 2
+  // Generate a bitmask of all 1s except the last 2 bits (N and C axes) when dims.nbDims > 2
   uint32_t reduceAxes = ((1 << dims.nbDims) - 1) & ~0b11;
   // Generate a bitmask of all 1s except the last 1 bits (N axes) when dims.nbDims == 2. `aten::adaptive_avg_pool1d`'s
   // input can be (N, C, L) or (C, L).

--- a/core/plugins/impl/interpolate_plugin.cpp
+++ b/core/plugins/impl/interpolate_plugin.cpp
@@ -289,12 +289,18 @@ int InterpolatePlugin::enqueue(
       out = at::upsample_bilinear2d(input, {size_[0], size_[1]}, align_corners_);
     } else if (mode_ == "trilinear") {
       out = at::upsample_trilinear3d(input, {size_[0], size_[1], size_[2]}, align_corners_);
-    } else if(mode_ == "adaptive_avg_pool1d"){
+    } else if (mode_ == "adaptive_avg_pool1d") {
       out = at::adaptive_avg_pool1d(input, {size_[0]});
+    } else if (mode_ == "adaptive_max_pool1d") {
+      out = std::get<0>(at::adaptive_max_pool1d(input, {size_[0]}));
     } else if (mode_ == "adaptive_avg_pool2d") {
       out = at::adaptive_avg_pool2d(input, {size_[0], size_[1]});
     } else if (mode_ == "adaptive_max_pool2d") {
       out = std::get<0>(at::adaptive_max_pool2d(input, {size_[0], size_[1]}));
+    } else if (mode_ == "adaptive_avg_pool3d") {
+      out = at::adaptive_avg_pool3d(input, {size_[0], size_[1], size_[2]});
+    } else if (mode_ == "adaptive_max_pool3d") {
+      out = std::get<0>(at::adaptive_max_pool3d(input, {size_[0], size_[1], size_[2]}));
     }
   }
 

--- a/core/plugins/impl/interpolate_plugin.cpp
+++ b/core/plugins/impl/interpolate_plugin.cpp
@@ -289,6 +289,8 @@ int InterpolatePlugin::enqueue(
       out = at::upsample_bilinear2d(input, {size_[0], size_[1]}, align_corners_);
     } else if (mode_ == "trilinear") {
       out = at::upsample_trilinear3d(input, {size_[0], size_[1], size_[2]}, align_corners_);
+    } else if(mode_ == "adaptive_avg_pool1d"){
+      out = at::adaptive_avg_pool1d(input, {size_[0]});
     } else if (mode_ == "adaptive_avg_pool2d") {
       out = at::adaptive_avg_pool2d(input, {size_[0], size_[1]});
     } else if (mode_ == "adaptive_max_pool2d") {

--- a/tests/core/conversion/converters/test_pooling.cpp
+++ b/tests/core/conversion/converters/test_pooling.cpp
@@ -540,6 +540,32 @@ TEST(Converters, ATenAdaptiveAvgPool1DGlobalPoolingConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
+TEST(Converters, ATenAdaptiveAvgPool1DUsingPluginConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=3]()
+        %6 : int[] = prim::ListConstruct(%2)
+        %10 : Tensor = aten::adaptive_avg_pool1d(%0, %6)
+        return (%10))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_avg_pool1d needs a 3D input or a 2D input
+  auto in = at::randint(-5, 5, {1, 3, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 TEST(Converters, ATenAdaptiveMaxPool2DConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor):

--- a/tests/core/conversion/converters/test_pooling.cpp
+++ b/tests/core/conversion/converters/test_pooling.cpp
@@ -436,6 +436,32 @@ TEST(Converters, ATenAdaptiveAvgPool2DConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
+TEST(Converters, ATenAdaptiveAvgPool2DGlobalPoolingConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=1]()
+        %6 : int[] = prim::ListConstruct(%2, %3)
+        %10 : Tensor = aten::adaptive_avg_pool2d(%0, %6)
+        return (%10))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch PyTorch adaptive_avg_pool2d needs a 4D input or a 3D input
+  auto in = at::randint(-5, 5, {64, 16, 32, 32}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 TEST(Converters, ATenAdaptiveAvgPool2DConvertsCorrectlyWithDynamicInput) {
   const auto graph = R"IR(
       graph(%0 : Tensor):
@@ -486,6 +512,32 @@ TEST(Converters, ATenAdaptiveAvgPool1DConvertsCorrectly) {
   auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
 
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 1.0));
+}
+
+TEST(Converters, ATenAdaptiveAvgPool1DGlobalPoolingConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %6 : int[] = prim::ListConstruct(%2)
+        %10 : Tensor = aten::adaptive_avg_pool1d(%0, %6)
+        return (%10))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_avg_pool1d needs a 3D input or a 2D input
+  auto in = at::randint(-5, 5, {3, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
 TEST(Converters, ATenAdaptiveMaxPool2DConvertsCorrectly) {

--- a/tests/core/conversion/converters/test_pooling.cpp
+++ b/tests/core/conversion/converters/test_pooling.cpp
@@ -566,6 +566,58 @@ TEST(Converters, ATenAdaptiveAvgPool1DUsingPluginConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
+TEST(Converters, ATenAdaptiveMaxPool1DGlobalPoolingConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %6 : int[] = prim::ListConstruct(%2)
+        %10 : Tensor, %11 : Tensor = aten::adaptive_max_pool1d(%0, %6)
+        return (%10, %11))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_max_pool1d needs a 3D input or a 2D input
+  auto in = at::randint(-5, 5, {1, 3, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenAdaptiveMaxPool1DUsingPluginConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=3]()
+        %6 : int[] = prim::ListConstruct(%2)
+        %10 : Tensor, %11 : Tensor = aten::adaptive_max_pool1d(%0, %6)
+        return (%10, %11))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_max_pool1d needs a 3D input or a 2D input
+  auto in = at::randint(-5, 5, {1, 3, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 TEST(Converters, ATenAdaptiveMaxPool2DConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor):
@@ -614,6 +666,118 @@ TEST(Converters, ATenAdaptiveMaxPool2DConvertsCorrectlyWithDynamicInput) {
   auto trt_in = at::clone(in);
   params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
   auto trt_results = torch_tensorrt::tests::util::RunGraphEngineDynamic(g, params, {trt_in}, false);
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenAdaptiveAvgPool3DGlobalPoolingConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=1]()
+        %4 : int = prim::Constant[value=1]()
+        %6 : int[] = prim::ListConstruct(%2, %3, %4)
+        %10 : Tensor = aten::adaptive_avg_pool3d(%0, %6)
+        return (%10))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_avg_pool3d needs a 5D input or a 4D input
+  auto in = at::randint(-5, 5, {4, 5, 3, 15, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenAdaptiveAvgPool3DUsingPluginConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=7]()
+        %3 : int = prim::Constant[value=6]()
+        %4 : int = prim::Constant[value=5]()
+        %6 : int[] = prim::ListConstruct(%2, %3, %4)
+        %10 : Tensor = aten::adaptive_avg_pool3d(%0, %6)
+        return (%10))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_avg_pool3d needs a 5D input or a 4D input
+  auto in = at::randint(-5, 5, {4, 5, 3, 15, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenAdaptiveMaxPool3DGlobalPoolingConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=1]()
+        %4 : int = prim::Constant[value=1]()
+        %6 : int[] = prim::ListConstruct(%2, %3, %4)
+        %10 : Tensor, %11 : Tensor = aten::adaptive_max_pool3d(%0, %6)
+        return (%10, %11))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_max_pool3d needs a 5D input or a 4D input
+  auto in = at::randint(-5, 5, {5, 3, 15, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenAdaptiveMaxPool3DUsingPluginConvertsCorrectly) {
+  const auto graph =
+      R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=7]()
+        %3 : int = prim::Constant[value=8]()
+        %4 : int = prim::Constant[value=9]()
+        %6 : int[] = prim::ListConstruct(%2, %3, %4)
+        %10 : Tensor, %11 : Tensor = aten::adaptive_max_pool3d(%0, %6)
+        return (%10, %11))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  // PyTorch adaptive_max_pool3d needs a 5D input or a 4D input
+  auto in = at::randint(-5, 5, {4, 5, 3, 15, 16}, at::kCUDA);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
 
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #791 and support `aten::adaptive_max_pool1d`, `aten::adaptive_avg_pool3d` and `aten::adaptive_max_pool3d` operators.
Besides, #766  needs `aten::adaptive_avg_pool3d` operator.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes