### PR TITLE
Changed the docker run command in the notebook README file to avoid a warning message on container startup

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -21,7 +21,7 @@ docker build -t torch_tensorrt -f ./docker/Dockerfile .
 Then launch the container with:
 
 ```
-docker run --gpus=all --rm -it -v $PWD:/Torch-TensorRT --net=host torch_tensorrt bash
+docker run --gpus=all --rm -it -v $PWD:/Torch-TensorRT --net=host --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 torch_tensorrt bash
 ```
 
 Within the docker interactive bash session, start Jupyter with


### PR DESCRIPTION
Changed the docker run command in the notebook README file to avoid a warning message on container startup

Signed-off-by: Sven Chilton <sven.chilton@gmail.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes