### PR TITLE
refactor! feat: Add aten::reflection_pad2d and aten::reflection_pad1 converter support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you would like to build outside a docker container, please follow the section
 // Set input datatypes. Allowerd options torch::{kFloat, kHalf, kChar, kInt32, kBool}
 // Size of input_dtypes should match number of inputs to the network.
 // If input_dtypes is not set, default precision follows traditional PyT / TRT rules
-auto input = torch_tensorrt::Input(dims, torch::kHalf)
+auto input = torch_tensorrt::Input(dims, torch::kHalf);
 auto compile_settings = torch_tensorrt::ts::CompileSpec({input});
 // FP16 execution
 compile_settings.enabled_precisions = {torch::kHalf};

--- a/core/conversion/converters/BUILD
+++ b/core/conversion/converters/BUILD
@@ -71,6 +71,7 @@ cc_library(
         "impl/pooling.cpp",
         "impl/quantization.cpp",
         "impl/reduce.cpp",
+        "impl/reflection_pad.cpp",
         "impl/replication_pad.cpp",
         "impl/select.cpp",
         "impl/shuffle.cpp",

--- a/core/conversion/converters/impl/reflection_pad.cpp
+++ b/core/conversion/converters/impl/reflection_pad.cpp
@@ -1,0 +1,145 @@
+#include <ATen/ATen.h>
+#include <vector>
+#include "NvInfer.h"
+#include "core/conversion/converters/converters.h"
+#include "core/util/prelude.h"
+#include "torch/torch.h"
+
+namespace torch_tensorrt {
+namespace core {
+namespace conversion {
+namespace converters {
+namespace impl {
+namespace {
+
+auto reflection_padXd TORCHTRT_UNUSED =
+    RegisterNodeConversionPatterns()
+        .pattern({"aten::reflection_pad2d(Tensor self, int[4] padding) -> (Tensor)",
+                  [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+                    auto in = args[0].ITensor();
+                    auto inDims = in->getDimensions();
+                    int64_t inRank = inDims.nbDims;
+                    auto padding = args[1].unwrapToIntList().vec();
+                    if (padding.size() == 1) {
+                      for (int64_t i = 0; i < 3; i++)
+                        padding.push_back(padding[0]);
+                    }
+                    if (inRank == 4) {
+                      TORCHTRT_CHECK(padding.size() == 4, "4D tensors expect 4 values for padding");
+                    } else {
+                      TORCHTRT_THROW_ERROR("Only 4D padding are supported for now");
+                    }
+
+                    std::vector<nvinfer1::ITensor*> tensors_vec;
+                    // 2d padding: (padding_left, padding_right, padding_top, padding_bottom)
+
+                    for (int64_t i = 0; i < int(padding.size() / 2); i++) {
+                      int64_t axis = inRank - (i + 1); // axis = {inRank - 1, inRank - 2}
+                      int64_t padding_index = i * 2;
+
+                      if (padding[padding_index] > 0) { // left/top padding value
+                        tensors_vec.clear();
+
+                        for (int i = 0; i < padding[padding_index]; i++) {
+                          at::Tensor left_indices = torch::tensor({padding[padding_index] - i}, torch::kInt32);
+                          auto indicesTensor = tensor_to_const(ctx, left_indices);
+                          auto left_gather_layer = ctx->net->addGather(*in, *indicesTensor, axis);
+                          auto left_gather_out = left_gather_layer->getOutput(0);
+                          tensors_vec.push_back(left_gather_out);
+                        }
+                        tensors_vec.push_back(in);
+                        auto concat_layer = ctx->net->addConcatenation(tensors_vec.data(), tensors_vec.size());
+                        concat_layer->setAxis(axis);
+                        in = concat_layer->getOutput(0);
+                        inDims = in->getDimensions();
+                      }
+
+                      if (padding[padding_index + 1] > 0) { // right/bottom padding value
+                        tensors_vec.clear();
+                        tensors_vec.push_back(in);
+
+                        for (int i = 0; i < padding[padding_index + 1]; i++) {
+                          nvinfer1::ITensor* indicesTensor = NULL;
+                          auto indices = torch::tensor({inDims.d[axis] - 1 - (i + 1)}, torch::kInt32);
+                          indicesTensor = tensor_to_const(ctx, indices);
+                          auto right_gather_layer = ctx->net->addGather(*in, *indicesTensor, axis);
+                          auto right_gather_out = right_gather_layer->getOutput(0);
+                          tensors_vec.push_back(right_gather_out);
+                        }
+
+                        auto concat_layer = ctx->net->addConcatenation(tensors_vec.data(), tensors_vec.size());
+                        concat_layer->setAxis(axis);
+                        in = concat_layer->getOutput(0);
+                        inDims = in->getDimensions();
+                      }
+                    }
+                    auto out = ctx->AssociateValueAndTensor(n->outputs()[0], in);
+                    LOG_DEBUG("Output tensor shape: " << out->getDimensions());
+
+                    return true;
+                  }})
+        .pattern({"aten::reflection_pad1d(Tensor self, int[2] padding) -> (Tensor)",
+                  [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+                    auto in = args[0].ITensor();
+                    auto inDims = in->getDimensions();
+                    int64_t inRank = inDims.nbDims;
+                    auto padding = args[1].unwrapToIntList().vec();
+                    if (padding.size() == 1) {
+                      for (int64_t i = 0; i < 1; i++)
+                        padding.push_back(padding[0]);
+                    }
+
+                    std::vector<nvinfer1::ITensor*> tensors_vec;
+                    // 1d padding: (padding_left, padding_right)
+
+                    int64_t axis = inRank - 1;
+                    int64_t padding_index = 0;
+
+                    if (padding[padding_index] > 0) { // left padding value
+                      tensors_vec.clear();
+
+                      for (int i = 0; i < padding[padding_index]; i++) {
+                        at::Tensor left_indices = torch::tensor({padding[padding_index] - i}, torch::kInt32);
+                        auto indicesTensor = tensor_to_const(ctx, left_indices);
+                        auto left_gather_layer = ctx->net->addGather(*in, *indicesTensor, axis);
+                        auto left_gather_out = left_gather_layer->getOutput(0);
+                        tensors_vec.push_back(left_gather_out);
+                      }
+                      tensors_vec.push_back(in);
+                      auto concat_layer = ctx->net->addConcatenation(tensors_vec.data(), tensors_vec.size());
+                      concat_layer->setAxis(axis);
+                      in = concat_layer->getOutput(0);
+                      inDims = in->getDimensions();
+                    }
+
+                    if (padding[padding_index + 1] > 0) { // right padding value
+                      tensors_vec.clear();
+                      tensors_vec.push_back(in);
+
+                      for (int i = 0; i < padding[padding_index + 1]; i++) {
+                        nvinfer1::ITensor* indicesTensor = NULL;
+                        auto indices = torch::tensor({inDims.d[axis] - 1 - (i + 1)}, torch::kInt32);
+                        indicesTensor = tensor_to_const(ctx, indices);
+                        auto right_gather_layer = ctx->net->addGather(*in, *indicesTensor, axis);
+                        auto right_gather_out = right_gather_layer->getOutput(0);
+                        tensors_vec.push_back(right_gather_out);
+                      }
+
+                      auto concat_layer = ctx->net->addConcatenation(tensors_vec.data(), tensors_vec.size());
+                      concat_layer->setAxis(axis);
+                      in = concat_layer->getOutput(0);
+                      inDims = in->getDimensions();
+                    }
+
+                    auto out = ctx->AssociateValueAndTensor(n->outputs()[0], in);
+                    LOG_DEBUG("Output tensor shape: " << out->getDimensions());
+
+                    return true;
+                  }});
+
+} // namespace
+} // namespace impl
+} // namespace converters
+} // namespace conversion
+} // namespace core
+} // namespace torch_tensorrt

--- a/tests/core/conversion/converters/BUILD
+++ b/tests/core/conversion/converters/BUILD
@@ -84,6 +84,10 @@ converter_test(
 )
 
 converter_test(
+    name = "test_reflection_pad",
+)
+
+converter_test(
     name = "test_replication_pad",
 )
 
@@ -150,6 +154,7 @@ test_suite(
         ":test_normalize",
         ":test_pooling",
         ":test_reduce",
+        ":test_reflection_pad",
         ":test_replication_pad",
         ":test_select",
         ":test_shuffle",

--- a/tests/core/conversion/converters/test_reflection_pad.cpp
+++ b/tests/core/conversion/converters/test_reflection_pad.cpp
@@ -1,0 +1,54 @@
+#include <iostream>
+#include <string>
+#include "core/compiler.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+
+TEST(Converters, ATenReflection_pad2dTensorConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=2]()
+        %4 : int = prim::Constant[value=0]()
+        %5 : int[] = prim::ListConstruct(%1, %2, %3, %4)
+        %6 : Tensor = aten::reflection_pad2d(%0, %5)
+        return (%6))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {1, 3, 5, 5}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1});
+
+  params = torch_tensorrt::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
+TEST(Converters, ATenReflection_pad1dTensorConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : int = prim::Constant[value=2]()
+        %3 : int[] = prim::ListConstruct(%1, %2)
+        %4 : Tensor = aten::reflection_pad1d(%0, %3)
+        return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {1, 2, 4}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1});
+
+  params = torch_tensorrt::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}


### PR DESCRIPTION
Signed-off-by: Vadim Makarenkov <vadim_makarenkov@hotmail.co.uk>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Refactor of #611 for the 1.1.0a0+b652045d version
Add aten::reflection_pad2d and aten::reflection_pad1d support.
All credits to @chengyute 

Fixes #775 (full compilation) #545 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes