### PR TITLE
feat(aten::__range_length): Adding range length evaluator

### DIFF
--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -666,3 +666,39 @@ TEST(Evaluators, AtenFormatRaiseExceptionEvaluatesCorrectly) {
     ASSERT_TRUE(false);
   }
 }
+
+TEST(Evaluators, RangeLengthEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph():
+        %1 : int = prim::Constant[value=1]()
+        %2 : int = prim::Constant[value=10]()
+        %3 : int = prim::Constant[value=2]()
+        %4 : int = aten::__range_length(%1, %2, %3)
+        return (%3))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto jit_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g, {});
+  auto trt_results = torch_tensorrt::tests::util::EvaluateGraph(g->block(), {});
+
+  ASSERT_TRUE(jit_results[0] == trt_results[0]);
+}
+
+TEST(Evaluators, RangeLengthNegEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph():
+        %1 : int = prim::Constant[value=10]()
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=-2]()
+        %4 : int = aten::__range_length(%1, %2, %3)
+        return (%3))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto jit_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g, {});
+  auto trt_results = torch_tensorrt::tests::util::EvaluateGraph(g->block(), {});
+
+  ASSERT_TRUE(jit_results[0] == trt_results[0]);
+}


### PR DESCRIPTION
# Description

Adds an evaluator for `aten::__range_length`

Fixes #835 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes