### PR TITLE
Fix truncate long and double

### DIFF
--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -460,9 +460,6 @@ int main(int argc, char** argv) {
     compile_settings.debug = true;
   }
 
-  if (use_strict_types) {
-    compile_settings.strict_types = true;
-  }
 
   if (allow_gpu_fallback) {
     compile_settings.device.allow_gpu_fallback = true;
@@ -586,9 +583,6 @@ int main(int argc, char** argv) {
     compile_settings.workspace_size = args::get(workspace_size);
   }
 
-  if (max_batch_size) {
-    compile_settings.max_batch_size = args::get(max_batch_size);
-  }
 
   if (truncate_long_and_double) {
     compile_settings.truncate_long_and_double = true;

--- a/py/torch_tensorrt/csrc/tensorrt_classes.cpp
+++ b/py/torch_tensorrt/csrc/tensorrt_classes.cpp
@@ -216,6 +216,7 @@ core::CompileSpec CompileSpec::toInternalCompileSpec() {
   info.partition_info.enabled = torch_fallback.enabled;
   info.partition_info.min_block_size = torch_fallback.min_block_size;
   info.partition_info.forced_fallback_operators = torch_fallback.forced_fallback_operators;
+  info.partition_info.truncate_long_and_double = truncate_long_and_double;
   info.lower_info.forced_fallback_modules = torch_fallback.forced_fallback_modules;
   info.convert_info.engine_settings.truncate_long_and_double = truncate_long_and_double;
 


### PR DESCRIPTION
# Description

Fix python api bug that truncate_long_and_double value doesn't pass to info.partition_info.truncate_long_and_double which will be used in `getSegmentsOutputByRunning`

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes