### PR TITLE
support aten::roll

### DIFF
--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -195,6 +195,84 @@ TEST(Converters, ATenEmbeddingConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
 }
 
+TEST(Converters, ATenRollConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%1 : Tensor):
+            %2 : int[] = prim::Constant[value=[1, 0, 3, 7]]()
+            %3 : int[] = prim::Constant[value=[0, 1, 2, 3]]()
+            %4 : Tensor = aten::roll(%1, %2, %3)
+            return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  // Run Pytorch
+  auto in = at::randint(1, 10, {2, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenRollShiftsNegativeConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%1 : Tensor):
+            %2 : int[] = prim::Constant[value=[0, -3, -3]]()
+            %3 : int[] = prim::Constant[value=[1, 2, 3]]()
+            %4 : Tensor = aten::roll(%1, %2, %3)
+            return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  // Run Pytorch
+  auto in = at::randint(1, 10, {1, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenRollDimsNegativeConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%1 : Tensor):
+            %2 : int[] = prim::Constant[value=[0, -3, -3]]()
+            %3 : int[] = prim::Constant[value=[1, 2, -1]]()
+            %4 : Tensor = aten::roll(%1, %2, %3)
+            return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  // Run Pytorch
+  auto in = at::randint(1, 10, {1, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
 TEST(Converters, ATenSliceConvertsCorrectly) {
   const auto graph = R"IR(
         graph(%x.1 : Tensor):


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

support `aten::roll(Tensor self, int[1] shifts, int[1] dims=[]) -> (Tensor)`

Fixes #766 #785

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes