### PR TITLE
Add remainders' op

### DIFF
--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -44,6 +44,7 @@ void LowerGraph(std::shared_ptr<torch::jit::Graph>& g, LowerInfo lower_info) {
   passes::EliminateExceptionOrPassPattern(g);
   passes::ReduceToOperation(g);
   passes::ReduceGelu(g);
+  passes::ReduceRemainder(g);
   passes::RemoveContiguous(g);
   passes::ViewToReshape(g);
   passes::RemoveDropout(g);

--- a/core/lowering/passes/BUILD
+++ b/core/lowering/passes/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "op_aliasing.cpp",
         "reduce_to.cpp",
         "reduce_gelu.cpp",
+        "reduce_remainder.cpp",
         "remove_bn_dim_check.cpp",
         "remove_contiguous.cpp",
         "view_to_reshape.cpp",

--- a/core/lowering/passes/passes.h
+++ b/core/lowering/passes/passes.h
@@ -21,6 +21,7 @@ void LinearToAddMM(std::shared_ptr<torch::jit::Graph>& graph);
 void EliminateExceptionOrPassPattern(std::shared_ptr<torch::jit::Graph> graph);
 void ReduceToOperation(std::shared_ptr<torch::jit::Graph>& graph);
 void ReduceGelu(std::shared_ptr<torch::jit::Graph>& graph);
+void ReduceRemainder(std::shared_ptr<torch::jit::Graph>& graph);
 void MarkNodesForFallback(std::shared_ptr<torch::jit::Graph>& g, bool delete_delims);
 void RemoveBNDimCheck(std::shared_ptr<torch::jit::Graph> graph);
 void RemoveContiguous(std::shared_ptr<torch::jit::Graph>& graph);

--- a/core/lowering/passes/reduce_remainder.cpp
+++ b/core/lowering/passes/reduce_remainder.cpp
@@ -1,0 +1,48 @@
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include "core/util/prelude.h"
+
+namespace torch_tensorrt {
+namespace core {
+namespace lowering {
+namespace passes {
+
+void ReduceRemainder(std::shared_ptr<torch::jit::Graph>& graph) {
+  std::string remainder_pattern = R"IR(
+        graph(%self : Tensor, %other : Tensor):
+            %out : Tensor = aten::remainder(%self, %other)
+            return (%out))IR";
+
+  std::string remainder_reduce_pattern = R"IR(
+        graph(%self : Tensor, %other : Tensor):
+            %alpha : int = prim::Constant[value=1]()
+            %floor: Tensor = aten::floor_divide(%self, %other)
+            %prod: Tensor = aten::mul(%floor, %other)
+            %out: Tensor = aten::sub(%self, %prod, %alpha)
+            return (%out))IR";
+
+  std::string remainder_scalar_pattern = R"IR(
+        graph(%self : Tensor, %other : Scalar):
+            %out : Tensor = aten::remainder(%self, %other)
+            return (%out))IR";
+
+  std::string remainder_scalar_reduce_pattern = R"IR(
+        graph(%self : Tensor, %other : Scalar):
+            %alpha : int = prim::Constant[value=1]()
+            %floor: Tensor = aten::floor_divide(%self, %other)
+            %prod: Tensor = aten::mul(%floor, %other)
+            %out: Tensor = aten::sub(%self, %prod, %alpha)
+            return (%out))IR";
+
+  // replace aten::remainder with pointwise operations
+  torch::jit::SubgraphRewriter map_remainder_to_pointwise_ops;
+  map_remainder_to_pointwise_ops.RegisterRewritePattern(remainder_pattern, remainder_reduce_pattern);
+  map_remainder_to_pointwise_ops.RegisterRewritePattern(remainder_scalar_pattern, remainder_scalar_reduce_pattern);
+  map_remainder_to_pointwise_ops.runOnGraph(graph);
+
+  LOG_GRAPH("Post lowering of [aten::remainder] -> " << *graph);
+}
+
+} // namespace passes
+} // namespace lowering
+} // namespace core
+} // namespace torch_tensorrt

--- a/tests/core/lowering/BUILD
+++ b/tests/core/lowering/BUILD
@@ -47,6 +47,10 @@ lowering_test(
 )
 
 lowering_test(
+    name = "test_reduce_remainder",
+)
+
+lowering_test(
     name = "test_remove_detach_pass",
 )
 
@@ -82,6 +86,7 @@ test_suite(
         ":test_view_to_reshape_pass",
         ":test_remove_dropout_pass",
         ":test_reduce_to_pass",
+        ":test_reduce_remainder",
         ":test_reduce_gelu",
         ":test_unpack_hardswish",
         ":test_unpack_reduce_ops"

--- a/tests/core/lowering/test_reduce_remainder.cpp
+++ b/tests/core/lowering/test_reduce_remainder.cpp
@@ -1,0 +1,57 @@
+#include <string>
+#include "core/compiler.h"
+#include "core/lowering/passes/passes.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "torch/csrc/jit/ir/subgraph_matcher.h"
+
+TEST(LoweringPasses, ReduceRemainderCorrectly) {
+  std::string source_graph = R"IR(
+        graph(%self : Tensor, %other : Tensor):
+            %out : Tensor = aten::remainder(%self, %other)
+            return (%out))IR";
+  std::string target_graph = R"IR(
+        graph(%self : Tensor, %other : Tensor):
+                %alpha : int = prim::Constant[value=1]()
+                %floor: Tensor = aten::floor_divide(%self, %other)
+                %prod: Tensor = aten::mul(%floor, %other)
+                %out: Tensor = aten::sub(%self, %prod, %alpha)
+                return (%out))IR";
+
+  torch_tensorrt::core::util::logging::get_logger().set_reportable_log_level(
+      torch_tensorrt::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+  torch_tensorrt::core::lowering::passes::ReduceRemainder(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, ReduceRemainderScalarCorrectly) {
+  std::string source_graph = R"IR(
+        graph(%self : Tensor, %other : Scalar):
+            %out : Tensor = aten::remainder(%self, %other)
+            return (%out))IR";
+  std::string target_graph = R"IR(
+        graph(%self : Tensor, %other : Scalar):
+            %alpha : int = prim::Constant[value=1]()
+            %floor: Tensor = aten::floor_divide(%self, %other)
+            %prod: Tensor = aten::mul(%floor, %other)
+            %out: Tensor = aten::sub(%self, %prod, %alpha)
+            return (%out))IR";
+
+  torch_tensorrt::core::util::logging::get_logger().set_reportable_log_level(
+      torch_tensorrt::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+  torch_tensorrt::core::lowering::passes::ReduceRemainder(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}


### PR DESCRIPTION
Signed-off-by: Cheng Hang <chang@nvidia.com>

# Description

Add support for `aten::remainder.Tensor(Tensor self, Tensor other) -> (Tensor)` and `aten::remainder.Scalar(Tensor self, Scalar other) -> (Tensor)`, which required by Video Swin Transformer. Use lowering to break it down, into 3 steps: 'aten::floor_div->aten::mul->aten::sub'.

Fixes #766

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes