### PR TITLE
fix path typo in installation docs

### DIFF
--- a/docsrc/tutorials/installation.rst
+++ b/docsrc/tutorials/installation.rst
@@ -116,7 +116,7 @@ You need to download the tarball distributions of TensorRT and cuDNN from the NV
     * https://developer.nvidia.com/cudnn
     * https://developer.nvidia.com/tensorrt
 
-Place these files in a directory (the directories ``thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]`` exist for this purpose)
+Place these files in a directory (the directories ``third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]`` exist for this purpose)
 
 Then compile referencing the directory with the tarballs
 
@@ -127,7 +127,7 @@ Release Build
 
 .. code-block:: shell
 
-    bazel build //:libtorchtrt -c opt --distdir thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+    bazel build //:libtorchtrt -c opt --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
 
 A tarball with the include files and library can then be found in ``bazel-bin``
 
@@ -140,7 +140,7 @@ To build with debug symbols use the following command
 
 .. code-block:: shell
 
-    bazel build //:libtorchtrt -c dbg --distdir thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+    bazel build //:libtorchtrt -c dbg --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
 
 A tarball with the include files and library can then be found in ``bazel-bin``
 
@@ -151,7 +151,7 @@ To build using the pre-CXX11 ABI use the ``pre_cxx11_abi`` config
 
 .. code-block:: shell
 
-    bazel build //:libtorchtrt --config pre_cxx11_abi -c [dbg/opt] --distdir thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+    bazel build //:libtorchtrt --config pre_cxx11_abi -c [dbg/opt] --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
 
 A tarball with the include files and library can then be found in ``bazel-bin``
 


### PR DESCRIPTION
Signed-off-by: KamalM9 <kamal@intuitionmachines.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fix path typo in installation doc sources

## Type of change

Please delete options that are not relevant and/or add your own.

- Minor path typo fix

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes