### PR TITLE
Fix tensor list inputs in fallback partitioning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,18 +128,18 @@ http_archive(
 #   build_file = "@//third_party/tensorrt/local:BUILD"
 #)
 
-#########################################################################
-# Testing Dependencies (optional - comment out on aarch64)
-#########################################################################
-pip_install(
-    name = "torch_tensorrt_py_deps",
-    requirements = "//py:requirements.txt",
-)
+# #########################################################################
+# # Testing Dependencies (optional - comment out on aarch64)
+# #########################################################################
+# pip_install(
+#     name = "torch_tensorrt_py_deps",
+#     requirements = "//py:requirements.txt",
+# )
 
-pip_install(
-    name = "py_test_deps",
-    requirements = "//tests/py:requirements.txt",
-)
+# pip_install(
+#     name = "py_test_deps",
+#     requirements = "//tests/py:requirements.txt",
+# )
 
 pip_install(
     name = "pylinter_deps",

--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -416,7 +416,7 @@ void ConvertBlockToNetDef(
       EvaluateConditionalBlock(ctx, n);
     } else if (to_eval) {
       auto eval = EvaluateNode(ctx, n);
-      if (eval) {
+      if (eval && n->outputs().size() > 0) {
         if (n->outputs().size() > 1) { // For ListUnpack scenario
           if (eval.value().isTuple()) {
             auto eval_list = eval.value().toTuple();

--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -416,7 +416,7 @@ void ConvertBlockToNetDef(
       EvaluateConditionalBlock(ctx, n);
     } else if (to_eval) {
       auto eval = EvaluateNode(ctx, n);
-      if (eval && n->outputs().size() > 0) {
+      if (eval) {
         if (n->outputs().size() > 1) { // For ListUnpack scenario
           if (eval.value().isTuple()) {
             auto eval_list = eval.value().toTuple();

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -295,6 +295,7 @@ auto aten_registrations TORCHTRT_UNUSED =
                         for (int64_t i = 0; i < other_size; i++) {
                           self.push_back(other.get(i));
                         }
+                        return self;
                       } else {
                         TORCHTRT_THROW_ERROR(
                             "Unimplemented data type for aten::extend.t evaluator: "

--- a/core/conversion/var/Var.cpp
+++ b/core/conversion/var/Var.cpp
@@ -13,7 +13,7 @@ Var::Var() {
   type_ = Type::kNone;
 }
 
-Var::Var(const torch::jit::IValue* p) : type_(Type::kIValue) {
+Var::Var(torch::jit::IValue* p) : type_(Type::kIValue) {
   ptr_.ivalue = p;
 }
 
@@ -56,7 +56,7 @@ Var& Var::operator=(const Var& a) {
   return (*this);
 }
 
-Var& Var::operator=(const torch::jit::IValue* in) {
+Var& Var::operator=(torch::jit::IValue* in) {
   ptr_.ivalue = in;
   type_ = Type::kIValue;
   return (*this);
@@ -116,6 +116,10 @@ nvinfer1::ITensor* Var::ITensorOrFreeze(ConversionCtx* ctx) {
 }
 
 const torch::jit::IValue* Var::IValue() const {
+  return IValueMut();
+}
+
+torch::jit::IValue* Var::IValueMut() const {
   TORCHTRT_CHECK(isIValue(), "Requested IValue from Var, however Var type is " << type_name());
   if (type_ == Type::kIValue) {
     return ptr_.ivalue;

--- a/core/conversion/var/Var.h
+++ b/core/conversion/var/Var.h
@@ -17,13 +17,14 @@ class Var : torch::CustomClassHolder {
   enum Type { kITensor, kIValue, kNone };
 
   Var();
-  Var(const torch::jit::IValue* p);
+  Var(torch::jit::IValue* p);
   Var(nvinfer1::ITensor* p);
   Var(const Var& a);
   Var& operator=(const Var& a);
-  Var& operator=(const torch::jit::IValue* in);
+  Var& operator=(torch::jit::IValue* in);
   Var& operator=(nvinfer1::ITensor* in);
   const torch::jit::IValue* IValue() const;
+  torch::jit::IValue* IValueMut() const;
   nvinfer1::ITensor* ITensor() const;
 
   // TODO: Can we consolidate this in a way that prevents requesting invalid
@@ -63,7 +64,7 @@ class Var : torch::CustomClassHolder {
 
  private:
   union VarContainer {
-    const torch::jit::IValue* ivalue;
+    torch::jit::IValue* ivalue;
     nvinfer1::ITensor* tensor;
     void* none;
   };

--- a/core/partitioning/SegmentedBlock.h
+++ b/core/partitioning/SegmentedBlock.h
@@ -70,7 +70,7 @@ struct SegmentedBlock {
   }
   void eraseInput(size_t i);
   void eraseOutput(size_t i);
-  bool contain_raw_value(torch::jit::Value* input) {
+  bool contain_raw_value(torch::jit::Value* input) const {
     return old_to_new_.count(input);
   }
   void register_inshapes(std::vector<ir::Input>& in_shapes) {
@@ -91,7 +91,7 @@ struct SegmentedBlock {
   void update_target(SegmentedBlockTarget new_target) {
     target_ = new_target;
   }
-  enum SegmentedBlockTarget target() {
+  enum SegmentedBlockTarget target() const {
     return target_;
   }
 

--- a/cpp/bin/torchtrtc/BUILD
+++ b/cpp/bin/torchtrtc/BUILD
@@ -10,7 +10,14 @@ config_setting(
 cc_binary(
     name = "torchtrtc",
     srcs = [
+        "accuracy.h",
+        "accuracy.cpp",
+        "fileio.h",
+        "fileio.cpp",
+        "luts.h",
         "main.cpp",
+        "parser_util.h",
+        "parser_util.cpp"
     ],
     deps = [
         "//third_party/args",

--- a/cpp/bin/torchtrtc/README.md
+++ b/cpp/bin/torchtrtc/README.md
@@ -31,17 +31,12 @@ torchtrtc [input_file_path] [output_file_path]
         --i, --info                       Dumps info messages generated during
                                           compilation onto the console
       --build-debuggable-engine         Creates a debuggable engine
-      --use-strict-types                Restrict operating type to only use set
-                                        operation precision
       --allow-gpu-fallback              (Only used when targeting DLA
                                         (device-type)) Lets engine run layers on
                                         GPU if they are not supported on DLA
       --require-full-compilation        Require that the model should be fully
                                         compiled to TensorRT or throw an error
-      --is-supported=[method_name],
-      --supported=[method_name],
-      --check-support=[method_name],
-      --check-method-op-support=[method_name]
+      --check-method-support=[method_name]
                                         Check the support for end to end
                                         compilation of a specified method in the
                                         TorchScript module
@@ -79,8 +74,8 @@ torchtrtc [input_file_path] [output_file_path]
                                         (Repeatable) Module that should always
                                         be run in Pytorch for execution (partial
                                         compilation must be enabled)
-      --mbs=[min-block-size],
-      --min-block-size=[min-block-size] Minimum number of contiguous TensorRT
+      --mbs=[num_ops],
+      --min-block-size=[num_ops]        Minimum number of contiguous TensorRT
                                         supported ops to compile a subgraph to
                                         TensorRT
       --embed-engine                    Whether to treat input file as a
@@ -122,6 +117,7 @@ torchtrtc [input_file_path] [output_file_path]
                                         32)@f16%NHWC"
       "--" can be used to terminate flag options and force all following
       arguments to be treated as positional options
+
 ```
 
 e.g.

--- a/cpp/bin/torchtrtc/README.md
+++ b/cpp/bin/torchtrtc/README.md
@@ -14,12 +14,12 @@ to standard TorchScript. Load with `torch.jit.load()` and run like you would run
 
 ```
 torchtrtc [input_file_path] [output_file_path]
-  [input_specs...] {OPTIONS}
+    [input_specs...] {OPTIONS}
 
-  Torch-TensorRT is a compiler for TorchScript, it will compile and optimize
-  TorchScript programs to run on NVIDIA GPUs using TensorRT
+    torchtrtc is a compiler for TorchScript, it will compile and optimize
+    TorchScript programs to run on NVIDIA GPUs using TensorRT
 
-OPTIONS:
+  OPTIONS:
 
     -h, --help                        Display this help menu
     Verbiosity of the compiler

--- a/cpp/bin/torchtrtc/README.md
+++ b/cpp/bin/torchtrtc/README.md
@@ -21,101 +21,107 @@ torchtrtc [input_file_path] [output_file_path]
 
   OPTIONS:
 
-    -h, --help                        Display this help menu
-    Verbiosity of the compiler
-      -v, --verbose                     Dumps debugging information about the
-                                        compilation process onto the console
-      -w, --warnings                    Disables warnings generated during
-                                        compilation onto the console (warnings
-                                        are on by default)
-      --i, --info                       Dumps info messages generated during
-                                        compilation onto the console
-    --build-debuggable-engine         Creates a debuggable engine
-    --allow-gpu-fallback              (Only used when targeting DLA
-                                      (device-type)) Lets engine run layers on
-                                      GPU if they are not supported on DLA
-    --require-full-compilation        Require that the model should be fully
-                                      compiled to TensorRT or throw an error
-    --disable-tf32                    Prevent Float32 layers from using the
-                                      TF32 data format
-    --sparse-weights                  Enable sparsity for weights of conv and
-                                      FC layers
-    -p[precision...],
-    --enabled-precision=[precision...]
-                                      (Repeatable) Enabling an operating
-                                      precision for kernels to use when
-                                      building the engine (Int8 requires a
-                                      calibration-cache argument) [ float |
-                                      float32 | f32 | fp32 | half | float16 |
-                                      f16 | fp16 | int8 | i8 | char ]
-                                      (default: float)
-    -d[type], --device-type=[type]    The type of device the engine should be
-                                      built for [ gpu | dla ] (default: gpu)
-    --gpu-id=[gpu_id]                 GPU id if running on multi-GPU platform
-                                      (defaults to 0)
-    --dla-core=[dla_core]             DLACore id if running on available DLA
-                                      (defaults to 0)
-    --engine-capability=[capability]  The type of device the engine should be
-                                      built for [ standard | safety |
-                                      dla_standalone ]
-    --calibration-cache-file=[file_path]
-                                      Path to calibration cache file to use
-                                      for post training quantization
-    --teo=[torch-executed-ops...],
-    --torch-executed-ops=[torch-executed-ops...]
-                                      (Repeatable) Operator in the graph that
-                                      should always be run in PyTorch for
-                                      execution (partial compilation must be
-                                      enabled)
-    --tem=[torch-executed-mods...],
-    --torch-executed-mods=[torch-executed-mods...]
-                                      (Repeatable) Module that should always
-                                      be run in Pytorch for execution (partial
-                                      compilation must be enabled)
-    --mbs=[torch-executed-mods...],
-    --min-block-size=[torch-executed-mods...]
-                                      Minimum number of contiguous TensorRT
-                                      supported ops to compile a subgraph to
-                                      TensorRT
-    --embed-engine                    Whether to treat input file as a
-                                      serialized TensorRT engine and embed it
-                                      into a TorchScript module (device spec
-                                      must be provided)
-    --num-min-timing-iter=[num_iters] Number of minimization timing iterations
-                                      used to select kernels
-    --num-avg-timing-iters=[num_iters]
-                                      Number of averaging timing iterations
-                                      used to select kernels
-    --workspace-size=[workspace_size] Maximum size of workspace given to
-                                      TensorRT
-    -t[threshold],
-    --threshold=[threshold]           Maximum acceptable numerical deviation
-                                      from standard torchscript output
-                                      (default 2e-5)
-    --no-threshold-check              Skip checking threshold compliance
-    --truncate-long-double,
-    --truncate, --truncate-64bit      Truncate weights that are provided in
-                                      64bit to 32bit (Long, Double to Int,
-                                      Float)
-    --save-engine                     Instead of compiling a full a
-                                      TorchScript program, save the created
-                                      engine to the path specified as the
-                                      output path
-    input_file_path                   Path to input TorchScript file
-    output_file_path                  Path for compiled TorchScript (or
-                                      TensorRT engine) file
-    input_specs...                    Specs for inputs to engine, can either
-                                      be a single size or a range defined by
-                                      Min, Optimal, Max sizes, e.g.
-                                      "(N,..,C,H,W)"
-                                      "[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]".
-                                      Data Type and format can be specified by
-                                      adding an "@" followed by dtype and "%"
-                                      followed by format to the end of the
-                                      shape spec. e.g. "(3, 3, 32,
-                                      32)@f16%NHWC"
-    "--" can be used to terminate flag options and force all following
-    arguments to be treated as positional options
+      -h, --help                        Display this help menu
+      Verbiosity of the compiler
+        -v, --verbose                     Dumps debugging information about the
+                                          compilation process onto the console
+        -w, --warnings                    Disables warnings generated during
+                                          compilation onto the console (warnings
+                                          are on by default)
+        --i, --info                       Dumps info messages generated during
+                                          compilation onto the console
+      --build-debuggable-engine         Creates a debuggable engine
+      --use-strict-types                Restrict operating type to only use set
+                                        operation precision
+      --allow-gpu-fallback              (Only used when targeting DLA
+                                        (device-type)) Lets engine run layers on
+                                        GPU if they are not supported on DLA
+      --require-full-compilation        Require that the model should be fully
+                                        compiled to TensorRT or throw an error
+      --is-supported=[method_name],
+      --supported=[method_name],
+      --check-support=[method_name],
+      --check-method-op-support=[method_name]
+                                        Check the support for end to end
+                                        compilation of a specified method in the
+                                        TorchScript module
+      --disable-tf32                    Prevent Float32 layers from using the
+                                        TF32 data format
+      --sparse-weights                  Enable sparsity for weights of conv and
+                                        FC layers
+      -p[precision...],
+      --enable-precision=[precision...] (Repeatable) Enabling an operating
+                                        precision for kernels to use when
+                                        building the engine (Int8 requires a
+                                        calibration-cache argument) [ float |
+                                        float32 | f32 | fp32 | half | float16 |
+                                        f16 | fp16 | int8 | i8 | char ]
+                                        (default: float)
+      -d[type], --device-type=[type]    The type of device the engine should be
+                                        built for [ gpu | dla ] (default: gpu)
+      --gpu-id=[gpu_id]                 GPU id if running on multi-GPU platform
+                                        (defaults to 0)
+      --dla-core=[dla_core]             DLACore id if running on available DLA
+                                        (defaults to 0)
+      --engine-capability=[capability]  The type of device the engine should be
+                                        built for [ standard | safety |
+                                        dla_standalone ]
+      --calibration-cache-file=[file_path]
+                                        Path to calibration cache file to use
+                                        for post training quantization
+      --teo=[op_name...],
+      --torch-executed-op=[op_name...]  (Repeatable) Operator in the graph that
+                                        should always be run in PyTorch for
+                                        execution (partial compilation must be
+                                        enabled)
+      --tem=[module_name...],
+      --torch-executed-mod=[module_name...]
+                                        (Repeatable) Module that should always
+                                        be run in Pytorch for execution (partial
+                                        compilation must be enabled)
+      --mbs=[min-block-size],
+      --min-block-size=[min-block-size] Minimum number of contiguous TensorRT
+                                        supported ops to compile a subgraph to
+                                        TensorRT
+      --embed-engine                    Whether to treat input file as a
+                                        serialized TensorRT engine and embed it
+                                        into a TorchScript module (device spec
+                                        must be provided)
+      --num-min-timing-iter=[num_iters] Number of minimization timing iterations
+                                        used to select kernels
+      --num-avg-timing-iters=[num_iters]
+                                        Number of averaging timing iterations
+                                        used to select kernels
+      --workspace-size=[workspace_size] Maximum size of workspace given to
+                                        TensorRT
+      -t[threshold],
+      --threshold=[threshold]           Maximum acceptable numerical deviation
+                                        from standard torchscript output
+                                        (default 2e-5)
+      --no-threshold-check              Skip checking threshold compliance
+      --truncate-long-double,
+      --truncate, --truncate-64bit      Truncate weights that are provided in
+                                        64bit to 32bit (Long, Double to Int,
+                                        Float)
+      --save-engine                     Instead of compiling a full a
+                                        TorchScript program, save the created
+                                        engine to the path specified as the
+                                        output path
+      input_file_path                   Path to input TorchScript file
+      output_file_path                  Path for compiled TorchScript (or
+                                        TensorRT engine) file
+      input_specs...                    Specs for inputs to engine, can either
+                                        be a single size or a range defined by
+                                        Min, Optimal, Max sizes, e.g.
+                                        "(N,..,C,H,W)"
+                                        "[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]".
+                                        Data Type and format can be specified by
+                                        adding an "@" followed by dtype and "%"
+                                        followed by format to the end of the
+                                        shape spec. e.g. "(3, 3, 32,
+                                        32)@f16%NHWC"
+      "--" can be used to terminate flag options and force all following
+      arguments to be treated as positional options
 ```
 
 e.g.

--- a/cpp/bin/torchtrtc/accuracy.cpp
+++ b/cpp/bin/torchtrtc/accuracy.cpp
@@ -1,0 +1,27 @@
+#include "accuracy.h"
+
+#include "torch_tensorrt/logging.h"
+#include "torch_tensorrt/torch_tensorrt.h"
+
+namespace torchtrtc {
+namespace accuracy {
+
+bool check_rtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, float threshold) {
+  double maxValue = 0.0;
+  for (auto& tensor : inputs) {
+    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
+  }
+  torchtrt::logging::log(
+      torchtrt::logging::Level::kDEBUG,
+      std::string("Max Difference: ") + std::to_string(diff.abs().max().item<float>()));
+  torchtrt::logging::log(
+      torchtrt::logging::Level::kDEBUG, std::string("Acceptable Threshold: ") + std::to_string(threshold));
+  return diff.abs().max().item<float>() <= threshold * maxValue;
+}
+
+bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold) {
+  return check_rtol(a - b, {a, b}, threshold);
+}
+
+} // namespace accuracy
+} // namespace torchtrtc

--- a/cpp/bin/torchtrtc/accuracy.h
+++ b/cpp/bin/torchtrtc/accuracy.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "torch/script.h"
+#include "torch/torch.h"
+
+namespace torchtrtc {
+namespace accuracy {
+
+bool check_rtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, float threshold);
+bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold);
+
+} // namespace accuracy
+} // namespace torchtrtc

--- a/cpp/bin/torchtrtc/fileio.cpp
+++ b/cpp/bin/torchtrtc/fileio.cpp
@@ -1,0 +1,50 @@
+#include "fileio.h"
+
+namespace torchtrtc {
+namespace fileio {
+
+std::string read_buf(std::string const& path) {
+  std::string buf;
+  std::ifstream stream(path.c_str(), std::ios::binary);
+
+  if (stream) {
+    stream >> std::noskipws;
+    std::copy(std::istream_iterator<char>(stream), std::istream_iterator<char>(), std::back_inserter(buf));
+  }
+
+  return buf;
+}
+
+std::string get_cwd() {
+  char buff[FILENAME_MAX]; // create string buffer to hold path
+  if (getcwd(buff, FILENAME_MAX)) {
+    std::string current_working_dir(buff);
+    return current_working_dir;
+  } else {
+    torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Unable to get current directory");
+    exit(1);
+  }
+}
+
+std::string real_path(std::string path) {
+  auto abs_path = path;
+  char real_path_c[PATH_MAX];
+  char* res = realpath(abs_path.c_str(), real_path_c);
+  if (res) {
+    return std::string(real_path_c);
+  } else {
+    torchtrt::logging::log(torchtrt::logging::Level::kERROR, std::string("Unable to find file ") + abs_path);
+    exit(1);
+  }
+}
+
+std::string resolve_path(std::string path) {
+  auto rpath = path;
+  if (!(rpath.rfind("/", 0) == 0)) {
+    rpath = get_cwd() + '/' + rpath;
+  }
+  return rpath;
+}
+
+} // namespace fileio
+} // namespace torchtrtc

--- a/cpp/bin/torchtrtc/fileio.h
+++ b/cpp/bin/torchtrtc/fileio.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
+
+#ifdef __linux__
+#include <linux/limits.h>
+#else
+#define PATH_MAX 260
+#endif
+
+#if defined(_WIN32)
+#include <direct.h>
+#define getcwd _getcwd
+#define realpath(N, R) _fullpath((R), (N), PATH_MAX)
+#else
+#include <unistd.h>
+#endif
+
+#include "NvInfer.h"
+#include "third_party/args/args.hpp"
+#include "torch/script.h"
+#include "torch/torch.h"
+
+#include "torch_tensorrt/logging.h"
+#include "torch_tensorrt/ptq.h"
+#include "torch_tensorrt/torch_tensorrt.h"
+
+namespace torchtrtc {
+namespace fileio {
+
+std::string read_buf(std::string const& path);
+std::string get_cwd();
+std::string real_path(std::string path);
+std::string resolve_path(std::string path);
+
+} // namespace fileio
+} // namespace torchtrtc

--- a/cpp/bin/torchtrtc/luts.h
+++ b/cpp/bin/torchtrtc/luts.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "NvInfer.h"
+#include "third_party/args/args.hpp"
+#include "torch/script.h"
+#include "torch/torch.h"
+
+namespace torchtrtc {
+namespace luts {
+
+at::ScalarType to_torch_dtype(torchtrt::DataType dtype) {
+  switch (dtype) {
+    case torchtrt::DataType::kHalf:
+      return at::kHalf;
+    case torchtrt::DataType::kChar:
+      return at::kChar;
+    case torchtrt::DataType::kInt:
+      return at::kInt;
+    case torchtrt::DataType::kBool:
+      return at::kBool;
+    case torchtrt::DataType::kFloat:
+    default:
+      return at::kFloat;
+  }
+}
+
+const std::unordered_map<nvinfer1::DataType, at::ScalarType>& get_trt_at_type_map() {
+  static const std::unordered_map<nvinfer1::DataType, at::ScalarType> trt_at_type_map = {
+      {nvinfer1::DataType::kFLOAT, at::kFloat},
+      {nvinfer1::DataType::kHALF, at::kHalf},
+      {nvinfer1::DataType::kINT32, at::kInt},
+      {nvinfer1::DataType::kINT8, at::kChar},
+      {nvinfer1::DataType::kBOOL, at::kBool},
+  };
+  return trt_at_type_map;
+}
+
+} // namespace luts
+} // namespace torchtrtc

--- a/cpp/bin/torchtrtc/luts.h
+++ b/cpp/bin/torchtrtc/luts.h
@@ -8,7 +8,7 @@
 namespace torchtrtc {
 namespace luts {
 
-at::ScalarType to_torch_dtype(torchtrt::DataType dtype) {
+inline at::ScalarType to_torch_dtype(torchtrt::DataType dtype) {
   switch (dtype) {
     case torchtrt::DataType::kHalf:
       return at::kHalf;

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -53,11 +53,10 @@ int main(int argc, char** argv) {
       {"require-full-compilation"});
 
   args::ValueFlag<std::string> check_method_op_support(
-    parser,
-    "check-method-op-support",
-    "Check the support for end to end compilation of a specified method in the TorchScript module",
-    {"supported", "is-supported", "check-support", "check-method-op-support"}
-  );
+      parser,
+      "check-method-op-support",
+      "Check the support for end to end compilation of a specified method in the TorchScript module",
+      {"supported", "is-supported", "check-support", "check-method-op-support"});
 
   args::Flag disable_tf32(
       parser, "disable-tf32", "Prevent Float32 layers from using the TF32 data format", {"disable-tf32"});
@@ -196,7 +195,8 @@ int main(int argc, char** argv) {
   // Instead of compiling, just embed engine in a PyTorch module
   if (embed_engine) {
     auto device_str = args::get(device_type);
-    std::transform(device_str.begin(), device_str.end(), device_str.begin(), [](unsigned char c) { return std::tolower(c); });
+    std::transform(
+        device_str.begin(), device_str.end(), device_str.begin(), [](unsigned char c) { return std::tolower(c); });
 
     torchtrt::Device device;
 
@@ -224,7 +224,6 @@ int main(int argc, char** argv) {
     trt_mod.save(real_output_path);
     return 0;
   }
-
 
   std::vector<torchtrt::Input> ranges;
   for (const auto spec : args::get(input_shapes)) {
@@ -434,7 +433,8 @@ int main(int argc, char** argv) {
       }
 
       for (size_t i = 0; i < trt_results.size(); i++) {
-        if (!torchtrtc::accuracy::almost_equal(jit_results[i], trt_results[i].reshape_as(jit_results[i]), threshold_val)) {
+        if (!torchtrtc::accuracy::almost_equal(
+                jit_results[i], trt_results[i].reshape_as(jit_results[i]), threshold_val)) {
           std::ostringstream threshold_ss;
           threshold_ss << threshold_val;
           torchtrt::logging::log(

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
 
   args::ValueFlag<std::string> check_method_op_support(
       parser,
-      "check-method-op-support",
+      "method_name",
       "Check the support for end to end compilation of a specified method in the TorchScript module",
       {"supported", "is-supported", "check-support", "check-method-op-support"});
 
@@ -93,15 +93,15 @@ int main(int argc, char** argv) {
 
   args::ValueFlagList<std::string> torch_executed_ops(
       parser,
-      "torch-executed-ops",
+      "op_name",
       "(Repeatable) Operator in the graph that should always be run in PyTorch for execution (partial compilation must be enabled)",
-      {"teo", "torch-executed-ops"});
+      {"teo", "torch-executed-op"});
 
   args::ValueFlagList<std::string> torch_executed_mods(
       parser,
-      "torch-executed-mods",
+      "module_name",
       "(Repeatable) Module that should always be run in Pytorch for execution (partial compilation must be enabled)",
-      {"tem", "torch-executed-mods"});
+      {"tem", "torch-executed-mod"});
 
   args::ValueFlag<uint64_t> min_block_size(
       parser,

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -2,20 +2,6 @@
 #include <iostream>
 #include <sstream>
 
-#ifdef linux
-#include <linux/limits.h>
-#else
-#define PATH_MAX 260
-#endif
-
-#if defined(_WIN32)
-#include <direct.h>
-#define getcwd _getcwd
-#define realpath(N, R) _fullpath((R), (N), PATH_MAX)
-#else
-#include <unistd.h>
-#endif
-
 #include "NvInfer.h"
 #include "third_party/args/args.hpp"
 #include "torch/script.h"
@@ -25,187 +11,10 @@
 #include "torch_tensorrt/ptq.h"
 #include "torch_tensorrt/torch_tensorrt.h"
 
-at::ScalarType to_torch_dtype(torchtrt::DataType dtype) {
-  switch (dtype) {
-    case torchtrt::DataType::kHalf:
-      return at::kHalf;
-    case torchtrt::DataType::kChar:
-      return at::kChar;
-    case torchtrt::DataType::kInt:
-      return at::kInt;
-    case torchtrt::DataType::kBool:
-      return at::kBool;
-    case torchtrt::DataType::kFloat:
-    default:
-      return at::kFloat;
-  }
-}
-
-const std::unordered_map<nvinfer1::DataType, at::ScalarType>& get_trt_at_type_map() {
-  static const std::unordered_map<nvinfer1::DataType, at::ScalarType> trt_at_type_map = {
-      {nvinfer1::DataType::kFLOAT, at::kFloat},
-      {nvinfer1::DataType::kHALF, at::kHalf},
-      {nvinfer1::DataType::kINT32, at::kInt},
-      {nvinfer1::DataType::kINT8, at::kChar},
-      {nvinfer1::DataType::kBOOL, at::kBool},
-  };
-  return trt_at_type_map;
-}
-
-bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, float threshold) {
-  double maxValue = 0.0;
-  for (auto& tensor : inputs) {
-    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
-  }
-  torchtrt::logging::log(
-      torchtrt::logging::Level::kDEBUG,
-      std::string("Max Difference: ") + std::to_string(diff.abs().max().item<float>()));
-  torchtrt::logging::log(
-      torchtrt::logging::Level::kDEBUG, std::string("Acceptable Threshold: ") + std::to_string(threshold));
-  return diff.abs().max().item<float>() <= threshold * maxValue;
-}
-
-bool almostEqual(const at::Tensor& a, const at::Tensor& b, float threshold) {
-  return checkRtol(a - b, {a, b}, threshold);
-}
-
-torchtrt::TensorFormat parseTensorFormat(std::string str) {
-  std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) { return std::tolower(c); });
-
-  if (str == "linear" || str == "nchw" || str == "chw" || str == "contiguous") {
-    return torchtrt::TensorFormat::kContiguous;
-  } else if (str == "nhwc" || str == "hwc" || str == "channels_last") {
-    return torchtrt::TensorFormat::kChannelsLast;
-  } else {
-    torchtrt::logging::log(
-        torchtrt::logging::Level::kERROR,
-        "Invalid tensor format, options are [ linear | nchw | chw | contiguous | nhwc | hwc | channels_last ], found: " +
-            str);
-    return torchtrt::TensorFormat::kUnknown;
-  }
-}
-
-torchtrt::DataType parseDataType(std::string dtype_str) {
-  std::transform(
-      dtype_str.begin(), dtype_str.end(), dtype_str.begin(), [](unsigned char c) { return std::tolower(c); });
-  if (dtype_str == "float" || dtype_str == "float32" || dtype_str == "f32" || dtype_str == "fp32") {
-    return torchtrt::DataType::kFloat;
-  } else if (dtype_str == "half" || dtype_str == "float16" || dtype_str == "f16" || dtype_str == "fp16") {
-    return torchtrt::DataType::kHalf;
-  } else if (dtype_str == "char" || dtype_str == "int8" || dtype_str == "i8") {
-    return torchtrt::DataType::kChar;
-  } else if (dtype_str == "int" || dtype_str == "int32" || dtype_str == "i32") {
-    return torchtrt::DataType::kInt;
-  } else if (dtype_str == "bool" || dtype_str == "b") {
-    return torchtrt::DataType::kBool;
-  } else {
-    torchtrt::logging::log(
-        torchtrt::logging::Level::kERROR,
-        "Invalid precision, options are [ float | float32 | fp32 | f32 | half | float16 | fp16 | f16 | char | int8 | i8 | int | int32 | i32 | bool | b], found: " +
-            dtype_str);
-    return torchtrt::DataType::kUnknown;
-  }
-}
-
-std::vector<int64_t> parseSingleDim(std::string shape_str) {
-  std::vector<int64_t> shape;
-  std::stringstream ss;
-  for (auto c : shape_str) {
-    if (c == '(' || c == ' ') {
-      continue;
-    } else if (c == ',') {
-      int64_t dim;
-      ss >> dim;
-      shape.push_back(dim);
-      ss.clear();
-    } else if (c == ')') {
-      int64_t dim;
-      ss >> dim;
-      shape.push_back(dim);
-      ss.clear();
-      return shape;
-    } else {
-      ss << c;
-    }
-  }
-
-  torchtrt::logging::log(
-      torchtrt::logging::Level::kERROR,
-      "Shapes need dimensions delimited by comma in parentheses, \"(N,..,C,H,W)\"\n e.g \"(3,3,200,200)\"");
-  exit(1);
-  return {};
-}
-
-std::vector<std::vector<int64_t>> parseDynamicDim(std::string shape_str) {
-  shape_str = shape_str.substr(1, shape_str.size() - 2);
-  std::vector<std::vector<int64_t>> shape;
-  std::stringstream ss;
-
-  std::string delimiter = ";";
-
-  size_t pos = 0;
-  while ((pos = shape_str.find(delimiter)) != std::string::npos) {
-    auto token = shape_str.substr(0, pos);
-    auto range = parseSingleDim(token);
-    shape_str.erase(0, pos + delimiter.length());
-    shape.push_back(range);
-  }
-
-  auto range = parseSingleDim(shape_str);
-  shape.push_back(range);
-
-  if (shape.size() != 3) {
-    torchtrt::logging::log(
-        torchtrt::logging::Level::kERROR,
-        "Dynamic shapes need three sets of dimensions delimited by semi-colons, \"[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]\"\n e.g \"[(3,3,100,100);(3,3,200,200);(3,3,300,300)]\"");
-    exit(1);
-  }
-
-  return shape;
-}
-
-std::string read_buf(std::string const& path) {
-  std::string buf;
-  std::ifstream stream(path.c_str(), std::ios::binary);
-
-  if (stream) {
-    stream >> std::noskipws;
-    std::copy(std::istream_iterator<char>(stream), std::istream_iterator<char>(), std::back_inserter(buf));
-  }
-
-  return buf;
-}
-
-std::string get_cwd() {
-  char buff[FILENAME_MAX]; // create string buffer to hold path
-  if (getcwd(buff, FILENAME_MAX)) {
-    std::string current_working_dir(buff);
-    return current_working_dir;
-  } else {
-    torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Unable to get current directory");
-    exit(1);
-  }
-}
-
-std::string real_path(std::string path) {
-  auto abs_path = path;
-  char real_path_c[PATH_MAX];
-  char* res = realpath(abs_path.c_str(), real_path_c);
-  if (res) {
-    return std::string(real_path_c);
-  } else {
-    torchtrt::logging::log(torchtrt::logging::Level::kERROR, std::string("Unable to find file ") + abs_path);
-    exit(1);
-  }
-}
-
-std::string resolve_path(std::string path) {
-  auto rpath = path;
-  if (!(rpath.rfind("/", 0) == 0)) {
-    rpath = get_cwd() + '/' + rpath;
-  }
-  return rpath;
-}
+#include "accuracy.h"
+#include "fileio.h"
+#include "luts.h"
+#include "parser_util.h"
 
 int main(int argc, char** argv) {
   torchtrt::logging::set_is_colored_output_on(true);
@@ -242,6 +51,13 @@ int main(int argc, char** argv) {
       "require-full-compilation",
       "Require that the model should be fully compiled to TensorRT or throw an error",
       {"require-full-compilation"});
+
+  args::ValueFlag<std::string> check_method_op_support(
+    parser,
+    "check-method-op-support",
+    "Check the support for end to end compilation of a specified method in the TorchScript module",
+    {"supported", "is-supported", "check-support", "check-method-op-support"}
+  );
 
   args::Flag disable_tf32(
       parser, "disable-tf32", "Prevent Float32 layers from using the TF32 data format", {"disable-tf32"});
@@ -354,101 +170,67 @@ int main(int argc, char** argv) {
     torchtrt::logging::set_reportable_log_level(torchtrt::logging::Level::kERROR);
   }
 
-  std::vector<torchtrt::Input> ranges;
-  const std::string spec_err_str =
-      "Dimensions should be specified in one of these types \"(N,..,C,H,W)\" \"[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]\"\n e.g \"(3,3,300,300)\" \"[(3,3,100,100);(3,3,200,200);(3,3,300,300)]\"\nTo specify input type append an @ followed by the precision\n e.g. \"(3,3,300,300)@f32\"\nTo specify input format append an \% followed by the format [contiguous | channel_last]\n e.g. \"(3,3,300,300)@f32\%channel_last\"";
-  for (const auto spec : args::get(input_shapes)) {
-    std::string shapes;
-    std::string dtype;
-    std::string format;
-    // THERE IS A SPEC FOR DTYPE
-    if (spec.find('@') != std::string::npos) {
-      // THERE IS ALSO A SPEC FOR FORMAT
-      if (spec.find('%') != std::string::npos) {
-        auto dtype_delim = spec.find('@');
-        auto format_delim = spec.find('%');
-        std::string shapes = spec.substr(0, dtype_delim);
-        std::string dtype = spec.substr(dtype_delim + 1, format_delim - (dtype_delim + 1));
-        std::string format = spec.substr(format_delim + 1, spec.size());
+  auto real_input_path = torchtrtc::fileio::resolve_path(args::get(input_path));
 
-        auto parsed_dtype = parseDataType(dtype);
-        if (parsed_dtype == torchtrt::DataType::kUnknown) {
-          torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid datatype for input specification " + spec);
-          std::cerr << std::endl << parser;
-          exit(1);
-        }
-        auto parsed_format = parseTensorFormat(format);
-        if (parsed_format == torchtrt::TensorFormat::kUnknown) {
-          torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid format for input specification " + spec);
-          std::cerr << std::endl << parser;
-          exit(1);
-        }
-        if (shapes.rfind("(", 0) == 0) {
-          ranges.push_back(torchtrt::Input(parseSingleDim(shapes), parsed_dtype, parsed_format));
-        } else if (shapes.rfind("[", 0) == 0) {
-          auto dyn_shapes = parseDynamicDim(shapes);
-          ranges.push_back(torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2], parsed_dtype, parsed_format));
-        } else {
-          torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
-          std::cerr << std::endl << parser;
-          exit(1);
-        }
-        // THERE IS NO SPEC FOR FORMAT
-      } else {
-        std::string shapes = spec.substr(0, spec.find('@'));
-        std::string dtype = spec.substr(spec.find('@') + 1, spec.size());
-
-        auto parsed_dtype = parseDataType(dtype);
-        if (parsed_dtype == torchtrt::DataType::kUnknown) {
-          torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid datatype for input specification " + spec);
-          std::cerr << std::endl << parser;
-          exit(1);
-        }
-        if (shapes.rfind("(", 0) == 0) {
-          ranges.push_back(torchtrt::Input(parseSingleDim(shapes), parsed_dtype));
-        } else if (shapes.rfind("[", 0) == 0) {
-          auto dyn_shapes = parseDynamicDim(shapes);
-          ranges.push_back(torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2], parsed_dtype));
-        } else {
-          torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
-          std::cerr << std::endl << parser;
-          exit(1);
-        }
-      }
-      // THERE IS A SPEC FOR FORMAT BUT NOT DTYPE
-    } else if (spec.find('%') != std::string::npos) {
-      std::string shapes = spec.substr(0, spec.find('%'));
-      std::string format = spec.substr(spec.find('%') + 1, spec.size());
-
-      auto parsed_format = parseTensorFormat(format);
-      if (parsed_format == torchtrt::TensorFormat::kUnknown) {
-        torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid format for input specification " + spec);
-        std::cerr << std::endl << parser;
-        exit(1);
-      }
-      if (shapes.rfind("(", 0) == 0) {
-        ranges.push_back(torchtrt::Input(parseSingleDim(shapes), parsed_format));
-      } else if (shapes.rfind("[", 0) == 0) {
-        auto dyn_shapes = parseDynamicDim(shapes);
-        ranges.push_back(torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2], parsed_format));
-      } else {
-        torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
-        std::cerr << std::endl << parser;
-        exit(1);
-      }
-      // JUST SHAPE USE DEFAULT DTYPE
-    } else {
-      if (spec.rfind("(", 0) == 0) {
-        ranges.push_back(torchtrt::Input(parseSingleDim(spec)));
-      } else if (spec.rfind("[", 0) == 0) {
-        auto dyn_shapes = parseDynamicDim(spec);
-        ranges.push_back(torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2]));
-      } else {
-        torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
-        std::cerr << std::endl << parser;
-        exit(1);
-      }
+  if (check_method_op_support) {
+    torch::jit::Module mod;
+    try {
+      // Deserialize the ScriptModule from a file using torch::jit::load().
+      mod = torch::jit::load(real_input_path);
+    } catch (const c10::Error& e) {
+      torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Error loading the model (path may be incorrect)");
+      return 1;
     }
+
+    auto method = args::get(check_method_op_support);
+    auto result = torchtrt::ts::check_method_operator_support(mod, method);
+    if (result) {
+      std::cout << "The method is supported end to end by Torch-TensorRT" << std::endl;
+      return 0;
+    } else {
+      torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Method is not currently supported by Torch-TensorRT");
+      return 1;
+    }
+  }
+
+  auto real_output_path = torchtrtc::fileio::resolve_path(args::get(output_path));
+
+  // Instead of compiling, just embed engine in a PyTorch module
+  if (embed_engine) {
+    auto device_str = args::get(device_type);
+    std::transform(device_str.begin(), device_str.end(), device_str.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    torchtrt::Device device;
+
+    if (gpu_id) {
+      device.gpu_id = args::get(gpu_id);
+      torchtrt::set_device(device.gpu_id);
+    }
+
+    if (device_str == "gpu") {
+      device.device_type = torchtrt::Device::DeviceType::kGPU;
+    } else if (device_str == "dla") {
+      device.device_type = torchtrt::Device::DeviceType::kDLA;
+      if (dla_core) {
+        device.dla_core = args::get(dla_core);
+      }
+    } else {
+      torchtrt::logging::log(
+          torchtrt::logging::Level::kERROR, "Invalid device type, options are [ gpu | dla ] found: " + device_type);
+      std::cerr << std::endl << parser;
+      return 1;
+    }
+
+    std::string serialized_engine = torchtrtc::fileio::read_buf(real_input_path);
+    auto trt_mod = torchtrt::ts::embed_engine_in_new_module(serialized_engine, device);
+    trt_mod.save(real_output_path);
+    return 0;
+  }
+
+
+  std::vector<torchtrt::Input> ranges;
+  for (const auto spec : args::get(input_shapes)) {
+    ranges.push_back(torchtrtc::parserutil::parse_input(spec));
     std::stringstream ss;
     ss << "Parsed Input: " << ranges.back();
     torchtrt::logging::log(torchtrt::logging::Level::kDEBUG, ss.str());
@@ -474,7 +256,7 @@ int main(int argc, char** argv) {
 
   std::string calibration_cache_file_path = "";
   if (calibration_cache_file) {
-    calibration_cache_file_path = resolve_path(args::get(calibration_cache_file));
+    calibration_cache_file_path = torchtrtc::fileio::resolve_path(args::get(calibration_cache_file));
   }
 
   auto calibrator = torchtrt::ptq::make_int8_cache_calibrator(calibration_cache_file_path);
@@ -502,7 +284,7 @@ int main(int argc, char** argv) {
 
   if (enabled_precisions) {
     for (const auto precision : args::get(enabled_precisions)) {
-      auto dtype = parseDataType(precision);
+      auto dtype = torchtrtc::parserutil::parse_dtype(precision);
       if (dtype == torchtrt::DataType::kFloat) {
         compile_settings.enabled_precisions.insert(torch::kF32);
       } else if (dtype == torchtrt::DataType::kHalf) {
@@ -586,17 +368,6 @@ int main(int argc, char** argv) {
     compile_settings.truncate_long_and_double = true;
   }
 
-  auto real_input_path = resolve_path(args::get(input_path));
-  auto real_output_path = resolve_path(args::get(output_path));
-
-  // Instead of compiling, just embed engine in a PyTorch module
-  if (embed_engine) {
-    std::string serialized_engine = read_buf(real_input_path);
-    auto trt_mod = torchtrt::ts::embed_engine_in_new_module(serialized_engine, compile_settings.device);
-    trt_mod.save(real_output_path);
-    return 0;
-  }
-
   torch::jit::Module mod;
   try {
     // Deserialize the ScriptModule from a file using torch::jit::load().
@@ -636,7 +407,7 @@ int main(int argc, char** argv) {
 
       for (auto i : ranges) {
         auto in = at::randn(i.opt_shape, {at::kCUDA});
-        in = in.to(to_torch_dtype(i.dtype));
+        in = in.to(torchtrtc::luts::to_torch_dtype(i.dtype));
         jit_inputs_ivalues.push_back(in.clone());
         trt_inputs_ivalues.push_back(in.clone());
       }
@@ -665,7 +436,7 @@ int main(int argc, char** argv) {
       }
 
       for (size_t i = 0; i < trt_results.size(); i++) {
-        if (!almostEqual(jit_results[i], trt_results[i].reshape_as(jit_results[i]), threshold_val)) {
+        if (!torchtrtc::accuracy::almost_equal(jit_results[i], trt_results[i].reshape_as(jit_results[i]), threshold_val)) {
           std::ostringstream threshold_ss;
           threshold_ss << threshold_val;
           torchtrt::logging::log(

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -249,11 +249,11 @@ int main(int argc, char** argv) {
   args::Flag sparse_weights(
       parser, "sparse-weights", "Enable sparsity for weights of conv and FC layers", {"sparse-weights"});
 
-  args::ValueFlagList<std::string> enabled_precision(
+  args::ValueFlagList<std::string> enabled_precisions(
       parser,
       "precision",
       "(Repeatable) Enabling an operating precision for kernels to use when building the engine (Int8 requires a calibration-cache argument) [ float | float32 | f32 | fp32 | half | float16 | f16 | fp16 | int8 | i8 | char ] (default: float)",
-      {'p', "enabled-precision"});
+      {'p', "enable-precision"});
   args::ValueFlag<std::string> device_type(
       parser,
       "type",
@@ -500,8 +500,8 @@ int main(int argc, char** argv) {
     }
   }
 
-  if (enabled_precision) {
-    for (const auto precision : args::get(enabled_precision)) {
+  if (enabled_precisions) {
+    for (const auto precision : args::get(enabled_precisions)) {
       auto dtype = parseDataType(precision);
       if (dtype == torchtrt::DataType::kFloat) {
         compile_settings.enabled_precisions.insert(torch::kF32);

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -5,7 +5,6 @@
 #include "NvInfer.h"
 #include "third_party/args/args.hpp"
 #include "torch/script.h"
-#include "torch/torch.h"
 
 #include "torch_tensorrt/logging.h"
 #include "torch_tensorrt/ptq.h"
@@ -38,8 +37,7 @@ int main(int argc, char** argv) {
 
   args::Flag build_debuggable_engine(
       parser, "build-debuggable-engine", "Creates a debuggable engine", {"build-debuggable-engine"});
-  args::Flag use_strict_types(
-      parser, "use-strict-types", "Restrict operating type to only use set operation precision", {"use-strict-types"});
+
   args::Flag allow_gpu_fallback(
       parser,
       "allow-gpu-fallback",
@@ -56,7 +54,7 @@ int main(int argc, char** argv) {
       parser,
       "method_name",
       "Check the support for end to end compilation of a specified method in the TorchScript module",
-      {"supported", "is-supported", "check-support", "check-method-op-support"});
+      {"check-method-support"});
 
   args::Flag disable_tf32(
       parser, "disable-tf32", "Prevent Float32 layers from using the TF32 data format", {"disable-tf32"});
@@ -105,7 +103,7 @@ int main(int argc, char** argv) {
 
   args::ValueFlag<uint64_t> min_block_size(
       parser,
-      "min-block-size",
+      "num_ops",
       "Minimum number of contiguous TensorRT supported ops to compile a subgraph to TensorRT",
       {"mbs", "min-block-size"});
 

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -122,8 +122,6 @@ int main(int argc, char** argv) {
       parser, "num_iters", "Number of averaging timing iterations used to select kernels", {"num-avg-timing-iters"});
   args::ValueFlag<uint64_t> workspace_size(
       parser, "workspace_size", "Maximum size of workspace given to TensorRT", {"workspace-size"});
-  args::ValueFlag<uint64_t> max_batch_size(
-      parser, "max_batch_size", "Maximum batch size (must be >= 1 to be set, 0 means not set)", {"max-batch-size"});
   args::ValueFlag<double> threshold(
       parser,
       "threshold",

--- a/cpp/bin/torchtrtc/parser_util.cpp
+++ b/cpp/bin/torchtrtc/parser_util.cpp
@@ -1,0 +1,190 @@
+#include "parser_util.h"
+
+namespace torchtrtc {
+namespace parserutil {
+
+torchtrt::TensorFormat parse_tensor_format(std::string str) {
+  std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) { return std::tolower(c); });
+
+  if (str == "linear" || str == "nchw" || str == "chw" || str == "contiguous") {
+    return torchtrt::TensorFormat::kContiguous;
+  } else if (str == "nhwc" || str == "hwc" || str == "channels_last") {
+    return torchtrt::TensorFormat::kChannelsLast;
+  } else {
+    torchtrt::logging::log(
+        torchtrt::logging::Level::kERROR,
+        "Invalid tensor format, options are [ linear | nchw | chw | contiguous | nhwc | hwc | channels_last ], found: " +
+            str);
+    return torchtrt::TensorFormat::kUnknown;
+  }
+}
+
+torchtrt::DataType parse_dtype(std::string dtype_str) {
+  std::transform(
+      dtype_str.begin(), dtype_str.end(), dtype_str.begin(), [](unsigned char c) { return std::tolower(c); });
+  if (dtype_str == "float" || dtype_str == "float32" || dtype_str == "f32" || dtype_str == "fp32") {
+    return torchtrt::DataType::kFloat;
+  } else if (dtype_str == "half" || dtype_str == "float16" || dtype_str == "f16" || dtype_str == "fp16") {
+    return torchtrt::DataType::kHalf;
+  } else if (dtype_str == "char" || dtype_str == "int8" || dtype_str == "i8") {
+    return torchtrt::DataType::kChar;
+  } else if (dtype_str == "int" || dtype_str == "int32" || dtype_str == "i32") {
+    return torchtrt::DataType::kInt;
+  } else if (dtype_str == "bool" || dtype_str == "b") {
+    return torchtrt::DataType::kBool;
+  } else {
+    torchtrt::logging::log(
+        torchtrt::logging::Level::kERROR,
+        "Invalid precision, options are [ float | float32 | fp32 | f32 | half | float16 | fp16 | f16 | char | int8 | i8 | int | int32 | i32 | bool | b], found: " +
+            dtype_str);
+    return torchtrt::DataType::kUnknown;
+  }
+}
+
+std::vector<int64_t> parse_single_dim(std::string shape_str) {
+  std::vector<int64_t> shape;
+  std::stringstream ss;
+  for (auto c : shape_str) {
+    if (c == '(' || c == ' ') {
+      continue;
+    } else if (c == ',') {
+      int64_t dim;
+      ss >> dim;
+      shape.push_back(dim);
+      ss.clear();
+    } else if (c == ')') {
+      int64_t dim;
+      ss >> dim;
+      shape.push_back(dim);
+      ss.clear();
+      return shape;
+    } else {
+      ss << c;
+    }
+  }
+
+  torchtrt::logging::log(
+      torchtrt::logging::Level::kERROR,
+      "Shapes need dimensions delimited by comma in parentheses, \"(N,..,C,H,W)\"\n e.g \"(3,3,200,200)\"");
+  exit(1);
+  return {};
+}
+
+std::vector<std::vector<int64_t>> parse_dynamic_dim(std::string shape_str) {
+  shape_str = shape_str.substr(1, shape_str.size() - 2);
+  std::vector<std::vector<int64_t>> shape;
+  std::stringstream ss;
+
+  std::string delimiter = ";";
+
+  size_t pos = 0;
+  while ((pos = shape_str.find(delimiter)) != std::string::npos) {
+    auto token = shape_str.substr(0, pos);
+    auto range = parse_single_dim(token);
+    shape_str.erase(0, pos + delimiter.length());
+    shape.push_back(range);
+  }
+
+  auto range = parse_single_dim(shape_str);
+  shape.push_back(range);
+
+  if (shape.size() != 3) {
+    torchtrt::logging::log(
+        torchtrt::logging::Level::kERROR,
+        "Dynamic shapes need three sets of dimensions delimited by semi-colons, \"[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]\"\n e.g \"[(3,3,100,100);(3,3,200,200);(3,3,300,300)]\"");
+    exit(1);
+  }
+
+  return shape;
+}
+
+torchtrt::Input parse_input(std::string spec) {
+  const std::string spec_err_str =
+      "Dimensions should be specified in one of these types \"(N,..,C,H,W)\" \"[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]\"\n e.g \"(3,3,300,300)\" \"[(3,3,100,100);(3,3,200,200);(3,3,300,300)]\"\nTo specify input type append an @ followed by the precision\n e.g. \"(3,3,300,300)@f32\"\nTo specify input format append an \% followed by the format [contiguous | channel_last]\n e.g. \"(3,3,300,300)@f32\%channel_last\"";
+  std::string shapes;
+  std::string dtype;
+  std::string format;
+  // THERE IS A SPEC FOR DTYPE
+  if (spec.find('@') != std::string::npos) {
+    // THERE IS ALSO A SPEC FOR FORMAT
+    if (spec.find('%') != std::string::npos) {
+      auto dtype_delim = spec.find('@');
+      auto format_delim = spec.find('%');
+      std::string shapes = spec.substr(0, dtype_delim);
+      std::string dtype = spec.substr(dtype_delim + 1, format_delim - (dtype_delim + 1));
+      std::string format = spec.substr(format_delim + 1, spec.size());
+
+      auto parsed_dtype = parse_dtype(dtype);
+      if (parsed_dtype == torchtrt::DataType::kUnknown) {
+        torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid datatype for input specification " + spec);
+        exit(1);
+      }
+      auto parsed_format = parse_tensor_format(format);
+      if (parsed_format == torchtrt::TensorFormat::kUnknown) {
+        torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid format for input specification " + spec);
+        exit(1);
+      }
+      if (shapes.rfind("(", 0) == 0) {
+        return torchtrt::Input(parse_single_dim(shapes), parsed_dtype, parsed_format);
+      } else if (shapes.rfind("[", 0) == 0) {
+        auto dyn_shapes = parse_dynamic_dim(shapes);
+        return torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2], parsed_dtype, parsed_format);
+      } else {
+        torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
+        exit(1);
+      }
+      // THERE IS NO SPEC FOR FORMAT
+    } else {
+      std::string shapes = spec.substr(0, spec.find('@'));
+      std::string dtype = spec.substr(spec.find('@') + 1, spec.size());
+
+      auto parsed_dtype = parse_dtype(dtype);
+      if (parsed_dtype == torchtrt::DataType::kUnknown) {
+        torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid datatype for input specification " + spec);
+        exit(1);
+      }
+      if (shapes.rfind("(", 0) == 0) {
+        return torchtrt::Input(parse_single_dim(shapes), parsed_dtype);
+      } else if (shapes.rfind("[", 0) == 0) {
+        auto dyn_shapes = parse_dynamic_dim(shapes);
+        return torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2], parsed_dtype);
+      } else {
+        torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
+        exit(1);
+      }
+    }
+    // THERE IS A SPEC FOR FORMAT BUT NOT DTYPE
+  } else if (spec.find('%') != std::string::npos) {
+    std::string shapes = spec.substr(0, spec.find('%'));
+    std::string format = spec.substr(spec.find('%') + 1, spec.size());
+
+    auto parsed_format = parse_tensor_format(format);
+    if (parsed_format == torchtrt::TensorFormat::kUnknown) {
+      torchtrt::logging::log(torchtrt::logging::Level::kERROR, "Invalid format for input specification " + spec);
+      exit(1);
+    }
+    if (shapes.rfind("(", 0) == 0) {
+      return torchtrt::Input(parse_single_dim(shapes), parsed_format);
+    } else if (shapes.rfind("[", 0) == 0) {
+      auto dyn_shapes = parse_dynamic_dim(shapes);
+      return torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2], parsed_format);
+    } else {
+      torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
+      exit(1);
+    }
+    // JUST SHAPE USE DEFAULT DTYPE
+  } else {
+    if (spec.rfind("(", 0) == 0) {
+      return torchtrt::Input(parse_single_dim(spec));
+    } else if (spec.rfind("[", 0) == 0) {
+      auto dyn_shapes = parse_dynamic_dim(spec);
+      return torchtrt::Input(dyn_shapes[0], dyn_shapes[1], dyn_shapes[2]);
+    } else {
+      torchtrt::logging::log(torchtrt::logging::Level::kERROR, spec_err_str);
+      exit(1);
+    }
+  }
+}
+
+} // namespace parserutil
+} // namespace torchtrtc

--- a/cpp/bin/torchtrtc/parser_util.h
+++ b/cpp/bin/torchtrtc/parser_util.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <stdlib.h>
+#include <iostream>
+#include <sstream>
+
+#include "NvInfer.h"
+#include "third_party/args/args.hpp"
+#include "torch/script.h"
+#include "torch/torch.h"
+
+#include "torch_tensorrt/logging.h"
+#include "torch_tensorrt/ptq.h"
+#include "torch_tensorrt/torch_tensorrt.h"
+
+namespace torchtrtc {
+namespace parserutil {
+
+// String to TensorFormat Enum
+torchtrt::TensorFormat parse_tensor_format(std::string str);
+
+// String to data type
+torchtrt::DataType parse_dtype(std::string dtype_str);
+
+// String to a vector of ints which represents a dimension spec
+std::vector<int64_t> parse_single_dim(std::string shape_str);
+
+// String to a vector of 3 dimension specs specs (each a vector of ints)
+std::vector<std::vector<int64_t>> parse_dynamic_dim(std::string shape_str);
+
+// String to a torchtrt::Input
+torchtrt::Input parse_input(std::string input_specs);
+
+} // namespace parserutil
+} // namespace torchtrtc

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/tensorrt:21.10-py3
+FROM nvcr.io/nvidia/tensorrt:22.01-py3
 
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list

--- a/docsrc/tutorials/installation.rst
+++ b/docsrc/tutorials/installation.rst
@@ -116,7 +116,7 @@ You need to download the tarball distributions of TensorRT and cuDNN from the NV
     * https://developer.nvidia.com/cudnn
     * https://developer.nvidia.com/tensorrt
 
-Place these files in a directory (the directories ``thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]`` exist for this purpose)
+Place these files in a directory (the directories ``third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]`` exist for this purpose)
 
 Then compile referencing the directory with the tarballs
 
@@ -127,7 +127,7 @@ Release Build
 
 .. code-block:: shell
 
-    bazel build //:libtorchtrt -c opt --distdir thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+    bazel build //:libtorchtrt -c opt --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
 
 A tarball with the include files and library can then be found in ``bazel-bin``
 
@@ -140,7 +140,7 @@ To build with debug symbols use the following command
 
 .. code-block:: shell
 
-    bazel build //:libtorchtrt -c dbg --distdir thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+    bazel build //:libtorchtrt -c dbg --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
 
 A tarball with the include files and library can then be found in ``bazel-bin``
 
@@ -151,7 +151,7 @@ To build using the pre-CXX11 ABI use the ``pre_cxx11_abi`` config
 
 .. code-block:: shell
 
-    bazel build //:libtorchtrt --config pre_cxx11_abi -c [dbg/opt] --distdir thrid_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+    bazel build //:libtorchtrt --config pre_cxx11_abi -c [dbg/opt] --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
 
 A tarball with the include files and library can then be found in ``bazel-bin``
 

--- a/docsrc/tutorials/torchtrtc.rst
+++ b/docsrc/tutorials/torchtrtc.rst
@@ -17,12 +17,12 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
 .. code-block:: txt
 
     torchtrtc [input_file_path] [output_file_path]
-        [input_specs...] {OPTIONS}
+      [input_specs...] {OPTIONS}
 
-        torchtrtc is a compiler for TorchScript, it will compile and optimize
-        TorchScript programs to run on NVIDIA GPUs using TensorRT
+      torchtrtc is a compiler for TorchScript, it will compile and optimize
+      TorchScript programs to run on NVIDIA GPUs using TensorRT
 
-      OPTIONS:
+    OPTIONS:
 
         -h, --help                        Display this help menu
         Verbiosity of the compiler

--- a/docsrc/tutorials/torchtrtc.rst
+++ b/docsrc/tutorials/torchtrtc.rst
@@ -17,12 +17,12 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
 .. code-block:: txt
 
     torchtrtc [input_file_path] [output_file_path]
-      [input_specs...] {OPTIONS}
+        [input_specs...] {OPTIONS}
 
-      Torch-TensorRT is a compiler for TorchScript, it will compile and optimize
-      TorchScript programs to run on NVIDIA GPUs using TensorRT
+        torchtrtc is a compiler for TorchScript, it will compile and optimize
+        TorchScript programs to run on NVIDIA GPUs using TensorRT
 
-    OPTIONS:
+      OPTIONS:
 
         -h, --help                        Display this help menu
         Verbiosity of the compiler

--- a/docsrc/tutorials/torchtrtc.rst
+++ b/docsrc/tutorials/torchtrtc.rst
@@ -39,13 +39,16 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
                                           GPU if they are not supported on DLA
         --require-full-compilation        Require that the model should be fully
                                           compiled to TensorRT or throw an error
+        --check-method-support=[method_name]
+                                          Check the support for end to end
+                                          compilation of a specified method in the
+                                          TorchScript module
         --disable-tf32                    Prevent Float32 layers from using the
                                           TF32 data format
         --sparse-weights                  Enable sparsity for weights of conv and
                                           FC layers
         -p[precision...],
-        --enabled-precision=[precision...]
-                                          (Repeatable) Enabling an operating
+        --enable-precision=[precision...] (Repeatable) Enabling an operating
                                           precision for kernels to use when
                                           building the engine (Int8 requires a
                                           calibration-cache argument) [ float |
@@ -64,20 +67,18 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
         --calibration-cache-file=[file_path]
                                           Path to calibration cache file to use
                                           for post training quantization
-        --teo=[torch-executed-ops...],
-        --torch-executed-ops=[torch-executed-ops...]
-                                          (Repeatable) Operator in the graph that
+        --teo=[op_name...],
+        --torch-executed-op=[op_name...]  (Repeatable) Operator in the graph that
                                           should always be run in PyTorch for
                                           execution (partial compilation must be
                                           enabled)
-        --tem=[torch-executed-mods...],
-        --torch-executed-mods=[torch-executed-mods...]
+        --tem=[module_name...],
+        --torch-executed-mod=[module_name...]
                                           (Repeatable) Module that should always
                                           be run in Pytorch for execution (partial
                                           compilation must be enabled)
-        --mbs=[torch-executed-mods...],
-        --min-block-size=[torch-executed-mods...]
-                                          Minimum number of contiguous TensorRT
+        --mbs=[num_ops],
+        --min-block-size=[num_ops]        Minimum number of contiguous TensorRT
                                           supported ops to compile a subgraph to
                                           TensorRT
         --embed-engine                    Whether to treat input file as a
@@ -119,114 +120,6 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
                                           32)@f16%NHWC"
         "--" can be used to terminate flag options and force all following
         arguments to be treated as positional options
-    [input_specs...] {OPTIONS}
-
-    torchtrtc is a compiler for TorchScript, it will compile and optimize
-    TorchScript programs to run on NVIDIA GPUs using TensorRT
-
-  OPTIONS:
-
-      -h, --help                        Display this help menu
-      Verbiosity of the compiler
-        -v, --verbose                     Dumps debugging information about the
-                                          compilation process onto the console
-        -w, --warnings                    Disables warnings generated during
-                                          compilation onto the console (warnings
-                                          are on by default)
-        --i, --info                       Dumps info messages generated during
-                                          compilation onto the console
-      --build-debuggable-engine         Creates a debuggable engine
-      --use-strict-types                Restrict operating type to only use set
-                                        operation precision
-      --allow-gpu-fallback              (Only used when targeting DLA
-                                        (device-type)) Lets engine run layers on
-                                        GPU if they are not supported on DLA
-      --require-full-compilation        Require that the model should be fully
-                                        compiled to TensorRT or throw an error
-      --is-supported=[method_name],
-      --supported=[method_name],
-      --check-support=[method_name],
-      --check-method-op-support=[method_name]
-                                        Check the support for end to end
-                                        compilation of a specified method in the
-                                        TorchScript module
-      --disable-tf32                    Prevent Float32 layers from using the
-                                        TF32 data format
-      --sparse-weights                  Enable sparsity for weights of conv and
-                                        FC layers
-      -p[precision...],
-      --enable-precision=[precision...] (Repeatable) Enabling an operating
-                                        precision for kernels to use when
-                                        building the engine (Int8 requires a
-                                        calibration-cache argument) [ float |
-                                        float32 | f32 | fp32 | half | float16 |
-                                        f16 | fp16 | int8 | i8 | char ]
-                                        (default: float)
-      -d[type], --device-type=[type]    The type of device the engine should be
-                                        built for [ gpu | dla ] (default: gpu)
-      --gpu-id=[gpu_id]                 GPU id if running on multi-GPU platform
-                                        (defaults to 0)
-      --dla-core=[dla_core]             DLACore id if running on available DLA
-                                        (defaults to 0)
-      --engine-capability=[capability]  The type of device the engine should be
-                                        built for [ standard | safety |
-                                        dla_standalone ]
-      --calibration-cache-file=[file_path]
-                                        Path to calibration cache file to use
-                                        for post training quantization
-      --teo=[op_name...],
-      --torch-executed-op=[op_name...]  (Repeatable) Operator in the graph that
-                                        should always be run in PyTorch for
-                                        execution (partial compilation must be
-                                        enabled)
-      --tem=[module_name...],
-      --torch-executed-mod=[module_name...]
-                                        (Repeatable) Module that should always
-                                        be run in Pytorch for execution (partial
-                                        compilation must be enabled)
-      --mbs=[min-block-size],
-      --min-block-size=[min-block-size] Minimum number of contiguous TensorRT
-                                        supported ops to compile a subgraph to
-                                        TensorRT
-      --embed-engine                    Whether to treat input file as a
-                                        serialized TensorRT engine and embed it
-                                        into a TorchScript module (device spec
-                                        must be provided)
-      --num-min-timing-iter=[num_iters] Number of minimization timing iterations
-                                        used to select kernels
-      --num-avg-timing-iters=[num_iters]
-                                        Number of averaging timing iterations
-                                        used to select kernels
-      --workspace-size=[workspace_size] Maximum size of workspace given to
-                                        TensorRT
-      -t[threshold],
-      --threshold=[threshold]           Maximum acceptable numerical deviation
-                                        from standard torchscript output
-                                        (default 2e-5)
-      --no-threshold-check              Skip checking threshold compliance
-      --truncate-long-double,
-      --truncate, --truncate-64bit      Truncate weights that are provided in
-                                        64bit to 32bit (Long, Double to Int,
-                                        Float)
-      --save-engine                     Instead of compiling a full a
-                                        TorchScript program, save the created
-                                        engine to the path specified as the
-                                        output path
-      input_file_path                   Path to input TorchScript file
-      output_file_path                  Path for compiled TorchScript (or
-                                        TensorRT engine) file
-      input_specs...                    Specs for inputs to engine, can either
-                                        be a single size or a range defined by
-                                        Min, Optimal, Max sizes, e.g.
-                                        "(N,..,C,H,W)"
-                                        "[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]".
-                                        Data Type and format can be specified by
-                                        adding an "@" followed by dtype and "%"
-                                        followed by format to the end of the
-                                        shape spec. e.g. "(3, 3, 32,
-                                        32)@f16%NHWC"
-      "--" can be used to terminate flag options and force all following
-      arguments to be treated as positional options
 
 e.g.
 

--- a/docsrc/tutorials/torchtrtc.rst
+++ b/docsrc/tutorials/torchtrtc.rst
@@ -119,6 +119,114 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
                                           32)@f16%NHWC"
         "--" can be used to terminate flag options and force all following
         arguments to be treated as positional options
+    [input_specs...] {OPTIONS}
+
+    torchtrtc is a compiler for TorchScript, it will compile and optimize
+    TorchScript programs to run on NVIDIA GPUs using TensorRT
+
+  OPTIONS:
+
+      -h, --help                        Display this help menu
+      Verbiosity of the compiler
+        -v, --verbose                     Dumps debugging information about the
+                                          compilation process onto the console
+        -w, --warnings                    Disables warnings generated during
+                                          compilation onto the console (warnings
+                                          are on by default)
+        --i, --info                       Dumps info messages generated during
+                                          compilation onto the console
+      --build-debuggable-engine         Creates a debuggable engine
+      --use-strict-types                Restrict operating type to only use set
+                                        operation precision
+      --allow-gpu-fallback              (Only used when targeting DLA
+                                        (device-type)) Lets engine run layers on
+                                        GPU if they are not supported on DLA
+      --require-full-compilation        Require that the model should be fully
+                                        compiled to TensorRT or throw an error
+      --is-supported=[method_name],
+      --supported=[method_name],
+      --check-support=[method_name],
+      --check-method-op-support=[method_name]
+                                        Check the support for end to end
+                                        compilation of a specified method in the
+                                        TorchScript module
+      --disable-tf32                    Prevent Float32 layers from using the
+                                        TF32 data format
+      --sparse-weights                  Enable sparsity for weights of conv and
+                                        FC layers
+      -p[precision...],
+      --enable-precision=[precision...] (Repeatable) Enabling an operating
+                                        precision for kernels to use when
+                                        building the engine (Int8 requires a
+                                        calibration-cache argument) [ float |
+                                        float32 | f32 | fp32 | half | float16 |
+                                        f16 | fp16 | int8 | i8 | char ]
+                                        (default: float)
+      -d[type], --device-type=[type]    The type of device the engine should be
+                                        built for [ gpu | dla ] (default: gpu)
+      --gpu-id=[gpu_id]                 GPU id if running on multi-GPU platform
+                                        (defaults to 0)
+      --dla-core=[dla_core]             DLACore id if running on available DLA
+                                        (defaults to 0)
+      --engine-capability=[capability]  The type of device the engine should be
+                                        built for [ standard | safety |
+                                        dla_standalone ]
+      --calibration-cache-file=[file_path]
+                                        Path to calibration cache file to use
+                                        for post training quantization
+      --teo=[op_name...],
+      --torch-executed-op=[op_name...]  (Repeatable) Operator in the graph that
+                                        should always be run in PyTorch for
+                                        execution (partial compilation must be
+                                        enabled)
+      --tem=[module_name...],
+      --torch-executed-mod=[module_name...]
+                                        (Repeatable) Module that should always
+                                        be run in Pytorch for execution (partial
+                                        compilation must be enabled)
+      --mbs=[min-block-size],
+      --min-block-size=[min-block-size] Minimum number of contiguous TensorRT
+                                        supported ops to compile a subgraph to
+                                        TensorRT
+      --embed-engine                    Whether to treat input file as a
+                                        serialized TensorRT engine and embed it
+                                        into a TorchScript module (device spec
+                                        must be provided)
+      --num-min-timing-iter=[num_iters] Number of minimization timing iterations
+                                        used to select kernels
+      --num-avg-timing-iters=[num_iters]
+                                        Number of averaging timing iterations
+                                        used to select kernels
+      --workspace-size=[workspace_size] Maximum size of workspace given to
+                                        TensorRT
+      -t[threshold],
+      --threshold=[threshold]           Maximum acceptable numerical deviation
+                                        from standard torchscript output
+                                        (default 2e-5)
+      --no-threshold-check              Skip checking threshold compliance
+      --truncate-long-double,
+      --truncate, --truncate-64bit      Truncate weights that are provided in
+                                        64bit to 32bit (Long, Double to Int,
+                                        Float)
+      --save-engine                     Instead of compiling a full a
+                                        TorchScript program, save the created
+                                        engine to the path specified as the
+                                        output path
+      input_file_path                   Path to input TorchScript file
+      output_file_path                  Path for compiled TorchScript (or
+                                        TensorRT engine) file
+      input_specs...                    Specs for inputs to engine, can either
+                                        be a single size or a range defined by
+                                        Min, Optimal, Max sizes, e.g.
+                                        "(N,..,C,H,W)"
+                                        "[(MIN_N,..,MIN_C,MIN_H,MIN_W);(OPT_N,..,OPT_C,OPT_H,OPT_W);(MAX_N,..,MAX_C,MAX_H,MAX_W)]".
+                                        Data Type and format can be specified by
+                                        adding an "@" followed by dtype and "%"
+                                        followed by format to the end of the
+                                        shape spec. e.g. "(3, 3, 32,
+                                        32)@f16%NHWC"
+      "--" can be used to terminate flag options and force all following
+      arguments to be treated as positional options
 
 e.g.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+from distutils.command.clean import clean
 import nox
 import os
 
@@ -8,7 +9,7 @@ PYT_PATH='/opt/conda/lib/python3.8/site-packages' if not 'PYT_PATH' in os.enviro
 # TOP_DIR
 TOP_DIR=os.path.dirname(os.path.realpath(__file__)) if not 'TOP_DIR' in os.environ else os.environ["TOP_DIR"]
 
-nox.options.sessions = ["developer_tests-3"]
+nox.options.sessions = ["l0_api_tests-3"]
 
 def install_deps(session):
     print("Installing deps")
@@ -30,31 +31,6 @@ def install_torch_trt(session):
     session.chdir(os.path.join(TOP_DIR, "py"))
     session.run("python", "setup.py", "develop")
 
-def run_base_tests(session, use_host_env=False):
-    print("Running basic tests")
-    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
-    tests = [
-        "test_api.py",
-        "test_to_backend_api.py"
-    ]
-    for test in tests:
-        if use_host_env:
-            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
-        else:
-            session.run_always("python", test)
-
-
-# Install the latest build of torch-tensorrt
-@nox.session(python=["3"], reuse_venv=True)
-def developer_tests(session):
-    """Basic set of tests that need to pass for code to get merged"""
-    install_deps(session)
-    install_torch_trt(session)
-    download_models(session)
-    run_base_tests(session)
-
-# Download the dataset
-@nox.session(python=["3"], reuse_venv=True)
 def download_datasets(session):
     print("Downloading dataset to path", os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
     session.chdir(os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
@@ -68,98 +44,70 @@ def download_datasets(session):
                         os.path.join(TOP_DIR, 'tests/accuracy/datasets/data/cidar-10-batches-bin'),
                         external=True)
 
-# Download the model
-@nox.session(python=["3"], reuse_venv=True)
-def download_test_models(session):
-    download_models(session, use_host_env=True)
-
-# Train the model
-@nox.session(python=["3"], reuse_venv=True)
-def train_model(session):
+def train_model(session, use_host_env=False):
     session.chdir(os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
-    session.run_always('python',
-                        'main.py',
-                        '--lr', '0.01',
-                        '--batch-size', '128',
-                        '--drop-ratio', '0.15',
-                        '--ckpt-dir', 'vgg16_ckpts',
-                        '--epochs', '25',
-                        env={'PYTHONPATH': PYT_PATH})
+    if use_host_env:
+        session.run_always('python',
+            'main.py',
+            '--lr', '0.01',
+            '--batch-size', '128',
+            '--drop-ratio', '0.15',
+            '--ckpt-dir', 'vgg16_ckpts',
+            '--epochs', '25',
+            env={'PYTHONPATH': PYT_PATH})
 
-    # Export model
-    session.run_always('python',
+        session.run_always('python',
                         'export_ckpt.py',
-                        'vgg16_ckpts/ckpt_epoch25.pth',
-                        env={'PYTHONPATH': PYT_PATH})
+                        'vgg16_ckpts/ckpt_epoch25.pth')
+    else:
+        session.run_always('python',
+            'main.py',
+            '--lr', '0.01',
+            '--batch-size', '128',
+            '--drop-ratio', '0.15',
+            '--ckpt-dir', 'vgg16_ckpts',
+            '--epochs', '25')
 
-# Finetune the model
-@nox.session(python=["3"], reuse_venv=True)
-def finetune_model(session):
+        session.run_always('python',
+                'export_ckpt.py',
+                'vgg16_ckpts/ckpt_epoch25.pth')
+
+def finetune_model(session, use_host_env=False):
     # Install pytorch-quantization dependency
     session.install('pytorch-quantization', '--extra-index-url', 'https://pypi.ngc.nvidia.com')
-
     session.chdir(os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
-    session.run_always('python',
-                        'finetune_qat.py',
-                        '--lr', '0.01',
-                        '--batch-size', '128',
-                        '--drop-ratio', '0.15',
-                        '--ckpt-dir', 'vgg16_ckpts',
-                        '--start-from', '25',
-                        '--epochs', '26',
-                        env={'PYTHONPATH': PYT_PATH})
 
-    # Export model
-    session.run_always('python',
-                        'export_qat.py',
-                        'vgg16_ckpts/ckpt_epoch26.pth',
-                        env={'PYTHONPATH': PYT_PATH})
-
-# Run PTQ tests
-@nox.session(python=["3"], reuse_venv=True)
-def ptq_test(session):
-    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
-    session.run_always('cp', '-rf',
-                        os.path.join(TOP_DIR, 'examples/int8/training/vgg16', 'trained_vgg16.jit.pt'),
-                        '.',
-                        external=True)
-    tests = [
-        'test_ptq_dataloader_calibrator.py',
-        'test_ptq_to_backend.py',
-        'test_ptq_trt_calibrator.py'
-        ]
-    for test in tests:
-        session.run_always('python', test,
-                        env={'PYTHONPATH': PYT_PATH})
-
-# Run QAT tests
-@nox.session(python=["3"], reuse_venv=True)
-def qat_test(session):
-    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
-    session.run_always('cp', '-rf',
-                        os.path.join(TOP_DIR, 'examples/int8/training/vgg16', 'trained_vgg16_qat.jit.pt'),
-                        '.',
-                        external=True)
-
-    session.run_always('python',
-                        'test_qat_trt_accuracy.py',
-                        env={'PYTHONPATH': PYT_PATH})
-
-# Run Python API tests
-@nox.session(python=["3"], reuse_venv=True)
-def api_test(session):
-    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
-    tests = [
-            "test_api.py",
-            "test_to_backend_api.py"
-            ]
-    for test in tests:
+    if use_host_env:
         session.run_always('python',
-                            test,
+                            'finetune_qat.py',
+                            '--lr', '0.01',
+                            '--batch-size', '128',
+                            '--drop-ratio', '0.15',
+                            '--ckpt-dir', 'vgg16_ckpts',
+                            '--start-from', '25',
+                            '--epochs', '26',
                             env={'PYTHONPATH': PYT_PATH})
 
-# Clean up
-@nox.session(reuse_venv=True)
+        # Export model
+        session.run_always('python',
+                            'export_qat.py',
+                            'vgg16_ckpts/ckpt_epoch26.pth',
+                            env={'PYTHONPATH': PYT_PATH})
+    else:
+        session.run_always('python',
+                            'finetune_qat.py',
+                            '--lr', '0.01',
+                            '--batch-size', '128',
+                            '--drop-ratio', '0.15',
+                            '--ckpt-dir', 'vgg16_ckpts',
+                            '--start-from', '25',
+                            '--epochs', '26')
+
+        # Export model
+        session.run_always('python',
+                            'export_qat.py',
+                            'vgg16_ckpts/ckpt_epoch26.pth')
+
 def cleanup(session):
     target = [
         'examples/int8/training/vgg16/*.jit.pt',
@@ -174,3 +122,185 @@ def cleanup(session):
     session.run_always('bash', '-c',
                         str('rm -rf ') + target,
                         external=True)
+
+def run_base_tests(session, use_host_env=False):
+    print("Running basic tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = [
+        "test_api.py",
+        "test_to_backend_api.py"
+    ]
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+def run_accuracy_tests(session, use_host_env=False):
+    print("Running accuracy tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = []
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+def run_int8_accuracy_tests(session, use_host_env=False):
+    print("Running accuracy tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = [
+        "test_ptq_dataloader.py",
+        "test_ptq_to_backend.py",
+        "test_qat_trt_accuracy",
+    ]
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+def run_trt_compatibility_tests(session, use_host_env=False):
+    print("Running TensorRT compatibility tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = [
+        "test_trt_intercompatibilty.py",
+        "test_ptq_trt_calibrator.py",
+    ]
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+def run_dla_tests(session, use_host_env=False):
+    print("Running DLA tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = [
+        "test_api_dla.py",
+    ]
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+def run_multi_gpu_tests(session, use_host_env=False):
+    print("Running multi GPU tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = [
+        "test_multi_gpu.py",
+    ]
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+def run_l0_api_tests(session, use_host_env=False):
+    if not use_host_env:
+        install_deps(session)
+        install_torch_trt(session)
+    download_models(session, use_host_env)
+    run_base_tests(session, use_host_env)
+    cleanup(session)
+
+def run_l0_dla_tests(session, use_host_env=False):
+    if not use_host_env:
+        install_deps(session)
+        install_torch_trt(session)
+    download_models(session, use_host_env)
+    run_base_tests(session, use_host_env)
+    cleanup(session)
+
+def run_l1_accuracy_tests(session, use_host_env=False):
+    if not use_host_env:
+        install_deps(session)
+        install_torch_trt(session)
+    download_models(session, use_host_env)
+    download_datasets(session, use_host_env)
+    train_model(session, use_host_env)
+    run_accuracy_tests(session, use_host_env)
+    cleanup(session)
+
+def run_l1_int8_accuracy_tests(session, use_host_env=False):
+    if not use_host_env:
+        install_deps(session)
+        install_torch_trt(session)
+    download_models(session, use_host_env)
+    download_datasets(session, use_host_env)
+    train_model(session, use_host_env)
+    finetune_model(session, use_host_env)
+    run_int8_accuracy_tests(session, use_host_env)
+    cleanup(session)
+
+def run_l2_trt_compatibility_tests(session, use_host_env=False):
+    if not use_host_env:
+        install_deps(session)
+        install_torch_trt(session)
+    download_models(session, use_host_env)
+    run_trt_compatibility_tests(session, use_host_env)
+    cleanup(session)
+
+def run_l2_multi_gpu_tests(session, use_host_env=False):
+    if not use_host_env:
+        install_deps(session)
+        install_torch_trt(session)
+    download_models(session, use_host_env)
+    run_multi_gpu_tests(session, use_host_env)
+    cleanup(session)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l0_api_tests(session):
+    """When a developer needs to check correctness for a PR or something"""
+    run_l0_api_tests(session, use_host_env=False)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l0_api_tests_host_deps(session):
+    """When a developer needs to check basic api functionality using host dependencies"""
+    run_l0_api_tests(session, use_host_env=True)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l0_dla_tests_host_deps(session):
+    """When a developer needs to check basic api functionality using host dependencies"""
+    run_l0_dla_tests(session, use_host_env=True)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l1_accuracy_tests(session):
+    """Checking accuracy performance on various usecases"""
+    run_l1_accuracy_tests(session, use_host_env=False)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l1_accuracy_tests_host_deps(session):
+    """Checking accuracy performance on various usecases using host dependencies"""
+    run_l1_accuracy_tests(session, use_host_env=True)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l1_int8_accuracy_tests(session):
+    """Checking accuracy performance on various usecases"""
+    run_l1_int8_accuracy_tests(session, use_host_env=False)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l1_int8_accuracy_tests_host_deps(session):
+    """Checking accuracy performance on various usecases using host dependencies"""
+    run_l1_int8_accuracy_tests(session, use_host_env=True)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l2_trt_compatibility_tests(session):
+    """Makes sure that TensorRT Python and Torch-TensorRT can work together"""
+    run_l2_trt_compatibility_tests(session, use_host_env=False)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l2_trt_compatibility_tests_host_deps(session):
+    """Makes sure that TensorRT Python and Torch-TensorRT can work together using host dependencies"""
+    run_l2_trt_compatibility_tests(session, use_host_env=True)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l2_multi_gpu_tests(session):
+    """Makes sure that Torch-TensorRT can operate on multi-gpu systems"""
+    run_l2_multi_gpu_tests(session, use_host_env=False)
+
+@nox.session(python=["3"], reuse_venv=True)
+def l2_multi_gpu_tests_host_deps(session):
+    """Makes sure that Torch-TensorRT can operate on multi-gpu systems using host dependencies"""
+    run_l2_multi_gpu_tests(session, use_host_env=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,8 +4,54 @@ import os
 # Use system installed Python packages
 PYT_PATH='/opt/conda/lib/python3.8/site-packages' if not 'PYT_PATH' in os.environ else os.environ["PYT_PATH"]
 
-# Root directory for torch_tensorrt. Set according to docker container by default
-TOP_DIR='/torchtrt' if not 'TOP_DIR' in os.environ else os.environ["TOP_DIR"]
+# Set the root directory to the directory of the noxfile unless the user wants to
+# TOP_DIR
+TOP_DIR=os.path.dirname(os.path.realpath(__file__)) if not 'TOP_DIR' in os.environ else os.environ["TOP_DIR"]
+
+nox.options.sessions = ["developer_tests-3"]
+
+def install_deps(session):
+    print("Installing deps")
+    session.install("-r", os.path.join(TOP_DIR, "py", "requirements.txt"))
+    session.install("-r", os.path.join(TOP_DIR, "tests", "py", "requirements.txt"))
+
+def download_models(session, use_host_env=False):
+    print("Downloading test models")
+    session.install('timm')
+    print(TOP_DIR)
+    session.chdir(os.path.join(TOP_DIR, "tests", "modules"))
+    if use_host_env:
+        session.run_always('python', 'hub.py', env={'PYTHONPATH': PYT_PATH})
+    else:
+        session.run_always('python', 'hub.py')
+
+def install_torch_trt(session):
+    print("Installing latest torch-tensorrt build")
+    session.chdir(os.path.join(TOP_DIR, "py"))
+    session.run("python", "setup.py", "develop")
+
+def run_base_tests(session, use_host_env=False):
+    print("Running basic tests")
+    session.chdir(os.path.join(TOP_DIR, 'tests/py'))
+    tests = [
+        "test_api.py",
+        "test_to_backend_api.py"
+    ]
+    for test in tests:
+        if use_host_env:
+            session.run_always('python', test, env={'PYTHONPATH': PYT_PATH})
+        else:
+            session.run_always("python", test)
+
+
+# Install the latest build of torch-tensorrt
+@nox.session(python=["3"], reuse_venv=True)
+def developer_tests(session):
+    """Basic set of tests that need to pass for code to get merged"""
+    install_deps(session)
+    install_torch_trt(session)
+    download_models(session)
+    run_base_tests(session)
 
 # Download the dataset
 @nox.session(python=["3"], reuse_venv=True)
@@ -14,33 +60,29 @@ def download_datasets(session):
     session.chdir(os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
     session.run_always('wget', 'https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz', external=True)
     session.run_always('tar', '-xvzf', 'cifar-10-binary.tar.gz', external=True)
-    session.run_always('mkdir', '-p', 
+    session.run_always('mkdir', '-p',
                         os.path.join(TOP_DIR, 'tests/accuracy/datasets/data'),
                         external=True)
-    session.run_always('cp', '-rpf', 
+    session.run_always('cp', '-rpf',
                         os.path.join(TOP_DIR, 'examples/int8/training/vgg16/cifar-10-batches-bin'),
                         os.path.join(TOP_DIR, 'tests/accuracy/datasets/data/cidar-10-batches-bin'),
                         external=True)
 
 # Download the model
 @nox.session(python=["3"], reuse_venv=True)
-def download_models(session):
-    session.install('timm')
-    session.chdir('tests/modules')
-    session.run_always('python', 
-                        'hub.py',
-                        env={'PYTHONPATH': PYT_PATH})
+def download_test_models(session):
+    download_models(session, use_host_env=True)
 
 # Train the model
 @nox.session(python=["3"], reuse_venv=True)
 def train_model(session):
     session.chdir(os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
-    session.run_always('python', 
-                        'main.py', 
-                        '--lr', '0.01', 
-                        '--batch-size', '128', 
-                        '--drop-ratio', '0.15', 
-                        '--ckpt-dir', 'vgg16_ckpts', 
+    session.run_always('python',
+                        'main.py',
+                        '--lr', '0.01',
+                        '--batch-size', '128',
+                        '--drop-ratio', '0.15',
+                        '--ckpt-dir', 'vgg16_ckpts',
                         '--epochs', '25',
                         env={'PYTHONPATH': PYT_PATH})
 
@@ -57,17 +99,17 @@ def finetune_model(session):
     session.install('pytorch-quantization', '--extra-index-url', 'https://pypi.ngc.nvidia.com')
 
     session.chdir(os.path.join(TOP_DIR, 'examples/int8/training/vgg16'))
-    session.run_always('python', 
-                        'finetune_qat.py', 
-                        '--lr', '0.01', 
-                        '--batch-size', '128', 
-                        '--drop-ratio', '0.15', 
-                        '--ckpt-dir', 'vgg16_ckpts', 
-                        '--start-from', '25', 
+    session.run_always('python',
+                        'finetune_qat.py',
+                        '--lr', '0.01',
+                        '--batch-size', '128',
+                        '--drop-ratio', '0.15',
+                        '--ckpt-dir', 'vgg16_ckpts',
+                        '--start-from', '25',
                         '--epochs', '26',
                         env={'PYTHONPATH': PYT_PATH})
-    
-    # Export model 
+
+    # Export model
     session.run_always('python',
                         'export_qat.py',
                         'vgg16_ckpts/ckpt_epoch26.pth',
@@ -77,8 +119,8 @@ def finetune_model(session):
 @nox.session(python=["3"], reuse_venv=True)
 def ptq_test(session):
     session.chdir(os.path.join(TOP_DIR, 'tests/py'))
-    session.run_always('cp', '-rf', 
-                        os.path.join(TOP_DIR, 'examples/int8/training/vgg16', 'trained_vgg16.jit.pt'), 
+    session.run_always('cp', '-rf',
+                        os.path.join(TOP_DIR, 'examples/int8/training/vgg16', 'trained_vgg16.jit.pt'),
                         '.',
                         external=True)
     tests = [
@@ -94,8 +136,8 @@ def ptq_test(session):
 @nox.session(python=["3"], reuse_venv=True)
 def qat_test(session):
     session.chdir(os.path.join(TOP_DIR, 'tests/py'))
-    session.run_always('cp', '-rf', 
-                        os.path.join(TOP_DIR, 'examples/int8/training/vgg16', 'trained_vgg16_qat.jit.pt'), 
+    session.run_always('cp', '-rf',
+                        os.path.join(TOP_DIR, 'examples/int8/training/vgg16', 'trained_vgg16_qat.jit.pt'),
                         '.',
                         external=True)
 

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -303,6 +303,32 @@ TEST(Evaluators, FloorFloatIntEvaluatesCorrectly) {
   ASSERT_TRUE(jit_results[0] == trt_results[0]);
 }
 
+TEST(Evaluators, ATenExtendEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %1 : Tensor):
+        %2 : int = prim::Constant[value=0]()
+        %3 : Tensor[] = prim::ListConstruct(%0)
+        %4 : Tensor[] = prim::ListConstruct(%1)
+        aten::extend(%3, %4)
+        %5 : Tensor = aten::cat(%3, %2)
+        return (%5))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in0 = at::randint(1, 10, {3, 4}, {at::kCUDA});
+  auto in1 = at::randint(1, 10, {5, 4}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in0, in1});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in0, in1});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
 TEST(Evaluators, ATenAppendWithITensorEvaluatesCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor, %1 : Tensor):

--- a/tests/core/partitioning/test_resolve_nontensor_inputs.cpp
+++ b/tests/core/partitioning/test_resolve_nontensor_inputs.cpp
@@ -6,7 +6,27 @@
 #include "torch/csrc/jit/ir/irparser.h"
 #include "torch/script.h"
 
-TEST(Partitioning, ResolveNonTensorInputsCorrectly) {
+bool checkSegmentedBlockInputType(const torch_tensorrt::core::partitioning::SegmentedBlock &segmented_block,
+                                  const std::function<bool(torch::jit::TypePtr)> &condition) {
+  for (auto input : segmented_block.raw_inputs()) {
+    if (!condition(input->type())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int count_trt_engines(std::shared_ptr<torch::jit::Graph> g) {
+  int count = 0;
+  for (const auto n : g->nodes()) {
+    if (n->kind().toQualString() == std::string("tensorrt::execute_engine")) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+TEST(Partitioning, ResolveNonTensorInputsForIFBlockCorrectly) {
   const auto graph = R"IR(
         graph(%x : Tensor, %y : Tensor):
           %0 : int = prim::Constant[value=0]()
@@ -67,4 +87,176 @@ TEST(Partitioning, ResolveNonTensorInputsCorrectly) {
   auto trt_results = new_mod.forward({trt_in0, trt_in1});
 
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results.toTensor(), trt_results.toTensor(), 2e-6));
+}
+
+TEST(Partitioning, ResolveNonTensorInputsCorrectly) {
+  const auto graph = R"IR(
+          graph(%0 : Float(1, 3, 16, 16, strides=[768, 256, 16, 1]),
+                %1 : Float(16, 3, 3, 3, strides=[27, 9, 3, 1]),
+                %2 : Float(16, strides=[1])):
+            %3 : int[] = prim::Constant[value=[0, 0]]()
+            %4 : int[] = prim::Constant[value=[1, 1]]()
+            %5 : bool = prim::Constant[value=0]()
+            %6 : bool = prim::Constant[value=1]()
+            %7 : int = prim::Constant[value=0]()
+            %8 : int = aten::size(%0, %7)
+            %9 : Tensor = aten::log_sigmoid(%0)
+            %10 : Tensor = aten::_convolution(%9, %1, %2, %4, %3, %4, %5, %3, %8, %5, %5, %6, %6)
+            %11 : Tensor = aten::relu(%10)
+            return (%11))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  torch_tensorrt::core::partitioning::PartitionInfo partition_info;
+  partition_info.enabled = true;
+  std::vector<torch_tensorrt::core::ir::Input> inputs;
+  inputs.push_back(torch_tensorrt::core::ir::Input({1, 3, 16, 16}));
+  inputs.push_back(torch_tensorrt::core::ir::Input({16, 3, 3, 3}));
+  inputs.push_back(torch_tensorrt::core::ir::Input({16}));
+
+  std::unordered_map<const torch::jit::Value*, torch_tensorrt::core::ir::Input> inputs_map;
+  std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>> input_types;
+  for (size_t i = 0; i < g->inputs().size(); ++i) {
+    inputs_map.insert({g->inputs()[i], inputs[i]});
+    input_types.insert({g->inputs()[i], {at::kFloat}});
+  }
+  auto input_ivalues_map = torch_tensorrt::core::partitioning::generateRandomInputs(inputs_map, input_types);
+  std::vector<torch_tensorrt::core::partitioning::SegmentedBlock> segmented_blocks =
+      torch_tensorrt::core::partitioning::Partition(g->block(), input_ivalues_map, partition_info);
+
+  int torch_block_cnt = 0, trt_block_cnt = 0;
+  for (const auto &segmented_block: segmented_blocks) {
+    if (segmented_block.target() == torch_tensorrt::core::partitioning::SegmentedBlock::kTensorRT) {
+      ++trt_block_cnt;
+      ASSERT_TRUE(checkSegmentedBlockInputType(
+            segmented_block,
+            [] (torch::jit::TypePtr type_ptr) { return type_ptr->isSubtypeOf(torch::jit::TensorType::get()); }));
+    } else {
+      ++torch_block_cnt;
+      ASSERT_TRUE(checkSegmentedBlockInputType(
+            segmented_block,
+            [] (torch::jit::TypePtr type_ptr) {
+              return type_ptr->isSubtypeOf(torch::jit::TensorType::get()) ||
+                  type_ptr->isSubtypeOf(torch::jit::ListType::ofTensors());
+            }));
+    }
+  }
+  ASSERT_TRUE(trt_block_cnt == 1 && torch_block_cnt == 1);
+}
+
+TEST(Partitioning, ResolveTensorListInputsInTrtCorrectly) {
+  const auto graph = R"IR(
+          graph(%0 : Float(1, 3, 16, 16, strides=[768, 256, 16, 1]),
+                %1 : Float(16, 6, 3, 3, strides=[54, 9, 3, 1]),
+                %2 : Float(16, strides=[1])):
+            %3 : int[] = prim::Constant[value=[0, 0]]()
+            %4 : int[] = prim::Constant[value=[1, 1]]()
+            %5 : bool = prim::Constant[value=0]()
+            %6 : bool = prim::Constant[value=1]()
+            %7 : int = prim::Constant[value=1]()
+            %8 : int = prim::Constant[value=0]()
+            %9 : Tensor[] = prim::ListConstruct(%0, %0)
+            %10 : Tensor = aten::cat(%9, %8)
+            %11 : Tensor = aten::log_sigmoid(%10)
+            %12 : Tensor = aten::cat(%9, %7)
+            %13 : Tensor = aten::_convolution(%12, %1, %2, %4, %3, %4, %5, %3, %7, %5, %5, %6, %6)
+            %14 : Tensor = aten::relu(%13)
+            %15 : (Tensor, Tensor) = prim::TupleConstruct(%11, %14)
+            return (%15))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  torch_tensorrt::core::partitioning::PartitionInfo partition_info;
+  partition_info.enabled = true;
+  std::vector<torch_tensorrt::core::ir::Input> inputs;
+  inputs.push_back(torch_tensorrt::core::ir::Input({1, 3, 16, 16}));
+  inputs.push_back(torch_tensorrt::core::ir::Input({16, 6, 3, 3}));
+  inputs.push_back(torch_tensorrt::core::ir::Input({16}));
+
+  std::unordered_map<const torch::jit::Value*, torch_tensorrt::core::ir::Input> inputs_map;
+  std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>> input_types;
+  for (size_t i = 0; i < g->inputs().size(); ++i) {
+    inputs_map.insert({g->inputs()[i], inputs[i]});
+    input_types.insert({g->inputs()[i], {at::kFloat}});
+  }
+  auto input_ivalues_map = torch_tensorrt::core::partitioning::generateRandomInputs(inputs_map, input_types);
+  std::vector<torch_tensorrt::core::partitioning::SegmentedBlock> segmented_blocks =
+      torch_tensorrt::core::partitioning::Partition(g->block(), input_ivalues_map, partition_info);
+
+  int torch_block_cnt = 0, trt_block_cnt = 0;
+  for (const auto &segmented_block: segmented_blocks) {
+    if (segmented_block.target() == torch_tensorrt::core::partitioning::SegmentedBlock::kTensorRT) {
+      ++trt_block_cnt;
+      ASSERT_TRUE(checkSegmentedBlockInputType(
+            segmented_block,
+            [] (torch::jit::TypePtr type_ptr) { return type_ptr->isSubtypeOf(torch::jit::TensorType::get()); }));
+    } else {
+      ++torch_block_cnt;
+      ASSERT_TRUE(checkSegmentedBlockInputType(
+            segmented_block,
+            [] (torch::jit::TypePtr type_ptr) {
+              return type_ptr->isSubtypeOf(torch::jit::TensorType::get()) ||
+                  type_ptr->isSubtypeOf(torch::jit::ListType::ofTensors());
+            }));
+    }
+  }
+  ASSERT_TRUE(trt_block_cnt == 2 && torch_block_cnt == 2);
+}
+
+TEST(Partitioning, ConvertForTensorListInputsInFallbackCorrectly) {
+  const auto graph = R"IR(
+          graph(%0 : Float(1, 3, 16, 16, strides=[768, 256, 16, 1]),
+                %1 : Float(16, 6, 3, 3, strides=[54, 9, 3, 1]),
+                %2 : Float(16, strides=[1])):
+            %3 : int[] = prim::Constant[value=[0, 0]]()
+            %4 : int[] = prim::Constant[value=[1, 1]]()
+            %5 : bool = prim::Constant[value=0]()
+            %6 : bool = prim::Constant[value=1]()
+            %7 : int = prim::Constant[value=1]()
+            %8 : int = prim::Constant[value=0]()
+            %9 : Tensor[] = prim::ListConstruct(%0, %0)
+            %11 : Tensor = aten::log_sigmoid(%0)
+            %12 : Tensor = aten::cat(%9, %7)
+            %13 : Tensor = aten::_convolution(%12, %1, %2, %4, %3, %4, %5, %3, %7, %5, %5, %6, %6)
+            %14 : Tensor = aten::relu(%13)
+            %15 : (Tensor, Tensor) = prim::TupleConstruct(%11, %14)
+            return (%15))IR";
+  auto parsed_g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, parsed_g.get());
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  std::vector<std::vector<int64_t>> all_shapes{{16, 6, 3, 3}, {16}};
+  std::unordered_map<torch::jit::Value*, torch::jit::Value*> tensor_to_constant;
+  for (size_t i = 0; i < all_shapes.size(); ++i) {
+    auto in = at::randn(all_shapes[i], {at::kCUDA});
+    torch::jit::IValue cur_val = in.clone();
+    auto new_val = g->insertConstant(cur_val);
+    tensor_to_constant[parsed_g->inputs()[i + 1]] = new_val;
+  }
+  for (auto node : parsed_g->nodes()) {
+    if (node->kind() == torch::jit::prim::Constant)
+      continue;
+    torch_tensorrt::core::util::cloneNode(node, g, tensor_to_constant);
+  }
+  g->registerOutput(tensor_to_constant[parsed_g->outputs()[0]]);
+
+  std::vector<torch_tensorrt::core::ir::Input> inputs;
+  inputs.push_back(torch_tensorrt::core::ir::Input({1, 3, 16, 16}));
+  torch_tensorrt::core::CompileSpec cfg(inputs);
+  cfg.partition_info.enabled = true;
+  torch::jit::script::Module mod(c10::QualifiedName("module"));
+
+  auto self = g->insertInput(0, "self_1");
+  self->setType(mod.type());
+  auto cur_method = mod._ivalue()->compilation_unit()->create_function(c10::QualifiedName("forward"), g);
+  auto schema = torch_tensorrt::core::util::GenerateGraphSchema(cur_method->name(), g);
+  mod.type()->addMethod(cur_method);
+  cur_method->setSchema(schema);
+
+  torch::jit::script::Module new_mod = torch_tensorrt::core::CompileGraph(mod, cfg);
+  auto fallback_g = new_mod.get_method("forward").graph();
+  int count = count_trt_engines(fallback_g);
+  ASSERT_TRUE(count == 2);
 }


### PR DESCRIPTION
Signed-off-by: MenglingD [dengmengling@meituan.com](dengmengling@meituan.com)

# Description

Fix TensorList inputs in tensorrt engine building after parititioning.

Fixes [#915 ](https://github.com/NVIDIA/Torch-TensorRT/issues/915)

After `resolveNonTensorInputBlocks` process, `resolveTensorListInputBlocks` is required for `tensorrt segmented blocks`. In `resolveTensorListInputBlocks` process, we find all nodes which depend `TensorList inputs` and produce non-tensor outputs, and appends those nodes to the producer's block of the depended `TensorList inputs`.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes