### PR TITLE
support aten::index.Tensor

### DIFF
--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -253,42 +253,46 @@ auto select_registrations TORCHTRT_UNUSED =
                       return true;
                     }
                   }})
-        .pattern({"aten::index.Tensor(Tensor self, Tensor?[] indices) -> (Tensor)",
-                  [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                    auto in = args[0].ITensorOrFreeze(ctx);
-                    auto ts = args[1].IValue()->toListRef();
+        .pattern(
+            {"aten::index.Tensor(Tensor self, Tensor?[] indices) -> (Tensor)",
+             [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+               auto in = args[0].ITensorOrFreeze(ctx);
+               auto ts = args[1].IValue()->toListRef();
 
-                    std::vector<nvinfer1::ITensor*> tensors;
-                    for (auto t : ts) {
-                      if (t.isTensor()) {
-                        auto torch_tensor = t.toTensor();
-                        tensors.push_back(tensor_to_const(ctx, torch_tensor));
-                      } else {
-                        auto cont = t.toCustomClass<TensorContainer>();
-                        tensors.push_back(cont->tensor());
-                      }
-                    }
+               std::vector<nvinfer1::ITensor*> tensors;
+               for (auto t : ts) {
+                 if (t.isTensor()) {
+                   auto torch_tensor = t.toTensor();
+                   tensors.push_back(tensor_to_const(ctx, torch_tensor));
+                 } else {
+                   auto cont = t.toCustomClass<TensorContainer>();
+                   tensors.push_back(cont->tensor());
+                 }
+               }
 
-                    TORCHTRT_CHECK(
-                        tensors.size() == 1,
-                        "This version of Torch-TensorRT only supports one index in aten::index.Tensor");
-                    auto indicesTensor = tensors[0];
-                    // Set datatype for indices tensor to INT32
-                    auto identity = ctx->net->addIdentity(*indicesTensor);
-                    identity->setOutputType(0, nvinfer1::DataType::kINT32);
-                    indicesTensor = identity->getOutput(0);
+               // In TorchScript, aten::index.Tensor indexes the self tensor along its each dimension by several
+               // indexes. In this version of Torch-TensorRT, it can only receive one index tensor which means it only
+               // indexes the self tensor along dimension 0.
+               TORCHTRT_CHECK(
+                   tensors.size() == 1,
+                   "In this version of Torch-TensorRT, aten::index.Tensor can only receive one index tensor which means it only indexes the self tensor along dimension 0.");
+               auto indicesTensor = tensors[0];
+               // Set datatype for indices tensor to INT32
+               auto identity = ctx->net->addIdentity(*indicesTensor);
+               identity->setOutputType(0, nvinfer1::DataType::kINT32);
+               indicesTensor = identity->getOutput(0);
 
-                    // IGatherLayer takes in input tensor, the indices, and the axis of input tensor to take indices
-                    // from
-                    auto gather_layer = ctx->net->addGather(*in, *indicesTensor, 0);
-                    TORCHTRT_CHECK(gather_layer, "Unable to create gather layer from node: " << *n);
-                    auto gather_out = gather_layer->getOutput(0);
+               // IGatherLayer takes in input tensor, the indices, and the axis of input tensor to take indices
+               // from
+               auto gather_layer = ctx->net->addGather(*in, *indicesTensor, 0);
+               TORCHTRT_CHECK(gather_layer, "Unable to create gather layer from node: " << *n);
+               auto gather_out = gather_layer->getOutput(0);
 
-                    auto out = ctx->AssociateValueAndTensor(n->outputs()[0], gather_out);
+               auto out = ctx->AssociateValueAndTensor(n->outputs()[0], gather_out);
 
-                    LOG_DEBUG("Output tensor shape: " << out->getDimensions());
-                    return true;
-                  }})
+               LOG_DEBUG("Output tensor shape: " << out->getDimensions());
+               return true;
+             }})
         .pattern(
             {"aten::slice.Tensor(Tensor(a) self, int dim=0, int? start=None, int? end=None, int step=1) -> Tensor(a)",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {

--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -541,3 +541,29 @@ TEST(Converters, ATenMaskedFillZerosConvertsCorrectly) {
   ASSERT_TRUE(
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
+
+TEST(Converters, ATenIndexTensorConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%x.1 : Tensor,
+            %index : Tensor):
+        %18 : Tensor?[] = prim::ListConstruct(%index)
+        %19 : Tensor = aten::index(%x.1, %18)
+        return (%19))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {5, 10}, {at::kCUDA});
+  auto in2 = at::full({2}, 4, {at::kCUDA});
+  auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+  auto in2_trt = at::full({2}, 4, {options});
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2_trt});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}

--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -195,6 +195,84 @@ TEST(Converters, ATenEmbeddingConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
 }
 
+TEST(Converters, ATenRollConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%1 : Tensor):
+            %2 : int[] = prim::Constant[value=[1, 0, 3, 7]]()
+            %3 : int[] = prim::Constant[value=[0, 1, 2, 3]]()
+            %4 : Tensor = aten::roll(%1, %2, %3)
+            return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  // Run Pytorch
+  auto in = at::randint(1, 10, {2, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenRollShiftsNegativeConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%1 : Tensor):
+            %2 : int[] = prim::Constant[value=[0, -3, -3]]()
+            %3 : int[] = prim::Constant[value=[1, 2, 3]]()
+            %4 : Tensor = aten::roll(%1, %2, %3)
+            return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  // Run Pytorch
+  auto in = at::randint(1, 10, {1, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenRollDimsNegativeConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%1 : Tensor):
+            %2 : int[] = prim::Constant[value=[0, -3, -3]]()
+            %3 : int[] = prim::Constant[value=[1, 2, -1]]()
+            %4 : Tensor = aten::roll(%1, %2, %3)
+            return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  // Run Pytorch
+  auto in = at::randint(1, 10, {1, 3, 4, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
 TEST(Converters, ATenSliceConvertsCorrectly) {
   const auto graph = R"IR(
         graph(%x.1 : Tensor):


### PR DESCRIPTION
# Description

`aten::index.Tensor(Tensor self, Tensor?[] indices) -> (Tensor)` is a complicated PyTorch function which can receive several indices. To focus on Video Swin Transformer, this version converter only supports one index. I will improve this converter in a future release.  

Fixes #766 


## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes