### PR TITLE
keep slopes ndim and in ndims the same

### DIFF
--- a/core/conversion/converters/impl/activation.cpp
+++ b/core/conversion/converters/impl/activation.cpp
@@ -105,7 +105,7 @@ auto acthardtanh TORCHTRT_UNUSED =
                  } else {
                    slopes_new_shape[original_shape.nbDims - 1] = slopes.sizes().vec()[0];
                  }
-                 slopes.reshape(slopes_new_shape);
+                 slopes = slopes.reshape(slopes_new_shape);
                }
 
                if (slopes.numel() != 1 &&

--- a/core/conversion/converters/impl/activation.cpp
+++ b/core/conversion/converters/impl/activation.cpp
@@ -90,21 +90,22 @@ auto acthardtanh TORCHTRT_UNUSED =
 
                // Out_tensor of ParametricReLU shape is all 0, when slopes nDims is not equal to in nDims.
                // Since make sure splopes nDims is equal to in nDims.
-               if(slopes.ndimension() == 1 and original_shape.nbDims != slopes.ndimension() ){
-                   std::vector<int64_t > slopes_new_shape(original_shape.nbDims,1 );
-                   auto first_inputs_allowed_formats = ctx->net->getInput(0)->getAllowedFormats();
-                   for(size_t inputs_index = 1;inputs_index < ctx->num_inputs;inputs_index++){
-                       auto inputs_allowed_formats = ctx->net->getInput(inputs_index)->getAllowedFormats();
-                       TORCHTRT_CHECK(first_inputs_allowed_formats == inputs_allowed_formats,
-                           "Unable to create batch prelu layer from node,since the formats(like NHWC or NCHW) of inputs is different: " << *n);
-                   }
-                   if( 1U << static_cast<int>(nvinfer1::TensorFormat::kLINEAR)==  first_inputs_allowed_formats ){
-                       slopes_new_shape[1] = slopes.sizes().vec()[0];
-                   }
-                   else{
-                       slopes_new_shape[original_shape.nbDims-1] = slopes.sizes().vec()[0];
-                   }
-                   slopes.reshape(slopes_new_shape);
+               if (slopes.ndimension() == 1 and original_shape.nbDims != slopes.ndimension()) {
+                 std::vector<int64_t> slopes_new_shape(original_shape.nbDims, 1);
+                 auto first_inputs_allowed_formats = ctx->net->getInput(0)->getAllowedFormats();
+                 for (size_t inputs_index = 1; inputs_index < ctx->num_inputs; inputs_index++) {
+                   auto inputs_allowed_formats = ctx->net->getInput(inputs_index)->getAllowedFormats();
+                   TORCHTRT_CHECK(
+                       first_inputs_allowed_formats == inputs_allowed_formats,
+                       "Unable to create batch prelu layer from node,since the formats(like NHWC or NCHW) of inputs is different: "
+                           << *n);
+                 }
+                 if (1U << static_cast<int>(nvinfer1::TensorFormat::kLINEAR) == first_inputs_allowed_formats) {
+                   slopes_new_shape[1] = slopes.sizes().vec()[0];
+                 } else {
+                   slopes_new_shape[original_shape.nbDims - 1] = slopes.sizes().vec()[0];
+                 }
+                 slopes.reshape(slopes_new_shape);
                }
 
                if (slopes.numel() != 1 &&

--- a/tests/core/conversion/converters/test_activation.cpp
+++ b/tests/core/conversion/converters/test_activation.cpp
@@ -134,6 +134,53 @@ TEST(Converters, ATenPReLUConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
+TEST(Converters, ATenPReLUChannelAlignConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1.1 : Float(3,strides=[1]),
+            %1 : Float(8, 3, 5, 5, strides=[45, 15, 5, 1]),
+            %2 : Float(8)):
+        %0.1 : Tensor = aten::prelu(%0, %1.1)
+        %3 : int = prim::Constant[value=1]()
+        %4 : int = prim::Constant[value=0]()
+        %5 : int = prim::Constant[value=1]()
+        %6 : int = prim::Constant[value=0]()
+        %7 : bool = prim::Constant[value=0]()
+        %8 : int[] = prim::ListConstruct(%3, %3)
+        %9 : int[] = prim::ListConstruct(%4, %4)
+        %10 : int[] = prim::ListConstruct(%5, %5)
+        %11 : int[] = prim::ListConstruct(%6, %6)
+        %12 : Tensor = aten::_convolution(%0.1, %1, %2, %8, %9, %10, %7, %11, %3, %7, %7, %7, %7)
+        return (%12))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = at::randint(1, 10, {1, 3, 10, 10}, {at::kCUDA});
+  auto w_prelu = at::randint(1, 10, {3}, {at::kCUDA});
+  auto w = at::randint(1, 10, {8, 3, 5, 5}, {at::kCUDA});
+  auto b = at::randint(1, 10, {8}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto jit_w_prelu = at::clone(w_prelu);
+  auto jit_w = at::clone(w);
+  auto jit_b = at::clone(b);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {jit_w_prelu, jit_w, jit_b});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_w_prelu = at::clone(w_prelu);
+  auto trt_w = at::clone(w);
+  auto trt_b = at::clone(b);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {trt_w_prelu, trt_w, trt_b});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 TEST(Converters, ATenPReLUMultiChannelConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor,


### PR DESCRIPTION
# Description

Out_tensor of ParametricReLU shape is all 0, when nDims of slopes is 1, and it not equal to nDims of input.
this pr make sure nDims of slopes is equal to nDims of input.

Fixes # (issue)

## Type of change
- Bug fix (non-breaking change which fixes an issue)
#789 
# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes