### PR TITLE
Fix bugs of ReduceToOperation

### DIFF
--- a/core/lowering/passes/reduce_to.cpp
+++ b/core/lowering/passes/reduce_to.cpp
@@ -9,20 +9,20 @@ namespace passes {
 
 void ReduceToOperation(std::shared_ptr<torch::jit::Graph>& graph) {
   std::string to_device_pattern = R"IR(
-        graph(%x, %device, %dtype, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %device, %dtype, %nb, %copy, %format)
+        graph(%x, %dtype, %device, %nb, %copy, %format):
+            %out : Tensor = aten::to(%x, %dtype, %device, %nb, %copy, %format)
             return (%out))IR";
   std::string to_dtype_pattern = R"IR(
-        graph(%x, %device, %dtype, %nb, %copy, %format):
+        graph(%x, %dtype, %device, %nb, %copy, %format):
             %out : Tensor = aten::to(%x, %dtype, %nb, %copy, %format)
             return (%out))IR";
   std::string to_dtype_layout_pattern = R"IR(
-        graph(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format)
+        graph(%x, %dtype, %device, %layout, %pm, %nb, %copy, %format):
+            %out : Tensor = aten::to(%x, %dtype, %device, %layout, %pm, %nb, %copy, %format)
             return (%out))IR";
 
   std::string to_dtype_multi_input_pattern = R"IR(
-        graph(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format):
+        graph(%x, %dtype, %device, %layout, %pm, %nb, %copy, %format):
             %out : Tensor = aten::to(%x, %dtype, %nb, %copy, %format)
             return (%out))IR";
 

--- a/tests/core/lowering/test_reduce_to_pass.cpp
+++ b/tests/core/lowering/test_reduce_to_pass.cpp
@@ -8,11 +8,11 @@
 
 TEST(LoweringPasses, ReduceToCorrectly) {
   std::string source_graph = R"IR(
-    graph(%x, %device, %dtype, %nb, %copy, %format):
-        %out : Tensor = aten::to(%x, %device, %dtype, %nb, %copy, %format)
+    graph(%x, %dtype, %device, %nb, %copy, %format):
+        %out : Tensor = aten::to(%x, %dtype, %device, %nb, %copy, %format)
         return (%out))IR";
   std::string target_graph = R"IR(
-    graph(%x, %device, %dtype, %nb, %copy, %format):
+    graph(%x, %dtype, %device, %nb, %copy, %format):
         %out : Tensor = aten::to(%x, %dtype, %nb, %copy, %format)
         return (%out))IR";
 
@@ -30,11 +30,11 @@ TEST(LoweringPasses, ReduceToCorrectly) {
 
 TEST(LoweringPasses, ReduceToDtypeLayoutCorrectly) {
   std::string source_graph = R"IR(
-    graph(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format):
-        %out : Tensor = aten::to(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format)
+    graph(%x, %dtype, %device, %layout, %pm, %nb, %copy, %format):
+        %out : Tensor = aten::to(%x, %dtype, %device, %layout, %pm, %nb, %copy, %format)
         return (%out))IR";
   std::string target_graph = R"IR(
-    graph(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format):
+    graph(%x, %dtype, %device, %layout, %pm, %nb, %copy, %format):
         %out : Tensor = aten::to(%x, %dtype, %nb, %copy, %format)
         return (%out))IR";
 


### PR DESCRIPTION
# Description
`ReduceToOperation()` contain bugs which will cause compilation failure. After inspecting the lowered graph of `ReduceToOperation`, we found it has mistakenly swapped the place of `device` and `dtype`. Which `device=0` and `dtype=6`, it will be reduced to `dtype=0` instead of `dtype=6`.

Fixes #954

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes