### PR TITLE
fix: fix bugs in aten::to

### DIFF
--- a/core/lowering/passes/reduce_to.cpp
+++ b/core/lowering/passes/reduce_to.cpp
@@ -8,22 +8,14 @@ namespace lowering {
 namespace passes {
 
 void ReduceToOperation(std::shared_ptr<torch::jit::Graph>& graph) {
-  std::string to_device_pattern = R"IR(
-        graph(%x, %device, %dtype, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %device, %dtype, %nb, %copy, %format)
-            return (%out))IR";
-  std::string to_dtype_pattern = R"IR(
-        graph(%x, %device, %dtype, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %dtype, %nb, %copy, %format)
-            return (%out))IR";
   std::string to_dtype_layout_pattern = R"IR(
-        graph(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format)
+        graph(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format):
+            %out : Tensor = aten::to(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format)
             return (%out))IR";
 
   std::string to_dtype_multi_input_pattern = R"IR(
-        graph(%x, %device, %dtype, %layout, %pm, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %dtype, %nb, %copy, %format)
+        graph(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format):
+            %out : Tensor = aten::to(%x, %device, %dtype, %nb, %copy, %format)
             return (%out))IR";
 
   std::string to_type_as_pattern = R"IR(
@@ -37,11 +29,6 @@ void ReduceToOperation(std::shared_ptr<torch::jit::Graph>& graph) {
             %6 : None = prim::Constant()
             %out : Tensor = aten::to(%input, %other, %5, %5, %6)
             return (%out))IR";
-
-  // replace aten::to.device with aten::to.dtype
-  torch::jit::SubgraphRewriter map_aten_device_to_dtype;
-  map_aten_device_to_dtype.RegisterRewritePattern(to_device_pattern, to_dtype_pattern);
-  map_aten_device_to_dtype.runOnGraph(graph);
 
   // replace aten::to.dtype_layout with aten::to.dtype
   torch::jit::SubgraphRewriter map_aten_dtype_layout;


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description
2 bugs found in our lowering pass for aten::to:
1: the argument mismatch in signatures
2: we are omitting the device info when we lower aten::to, this will incur the device mismatch problem in later Torchscript running part in our shape analysis for fallback.

Fixes # (issue)
 #941 
#954 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes