### PR TITLE
fix: Use user provided dtype when we can't infer it from the graph

### DIFF
--- a/core/compiler.cpp
+++ b/core/compiler.cpp
@@ -328,7 +328,8 @@ void MapInputsAndDetermineDTypes(
         spec.dtype = nvinfer1::DataType::kFLOAT;
       } else if (spec.dtype_is_user_defined && cfg.partition_info.enabled) {
         if (!est_type_opt) {
-          LOG_INFO("Cannot infer input tensor dtype in graph, unable to verify user input dtype settings");
+          LOG_INFO("Cannot infer input tensor dtype in graph. Using user provided input dtype settings");
+          first_use_type_map[in] = {util::TRTDataTypeToScalarType(cfg.convert_info.inputs.find(in)->second.dtype)};
         } else {
           if (util::TRTDataTypeToScalarType(cfg.convert_info.inputs.find(in)->second.dtype) != est_type_opt.value()) {
             std::stringstream ss;

--- a/core/ir/Input.cpp
+++ b/core/ir/Input.cpp
@@ -40,6 +40,13 @@ bool valid_dtype_format_combo(nvinfer1::DataType dtype, nvinfer1::TensorFormat f
         default:
           return false;
       }
+    case nvinfer1::DataType::kBOOL: // Supports Linear (NCHW)
+      switch (format) {
+        case nvinfer1::TensorFormat::kLINEAR:
+          return true;
+        default:
+          return false;
+      }
     default:
       return false;
   }
@@ -48,7 +55,7 @@ bool valid_dtype_format_combo(nvinfer1::DataType dtype, nvinfer1::TensorFormat f
 bool valid_input_dtype(nvinfer1::DataType dtype) {
   switch (dtype) {
     case nvinfer1::DataType::kBOOL:
-      return false;
+      return true;
     case nvinfer1::DataType::kFLOAT:
       return true;
     case nvinfer1::DataType::kHALF:

--- a/cpp/src/types.cpp
+++ b/cpp/src/types.cpp
@@ -157,13 +157,9 @@ Input::Input(std::vector<int64_t> shape, DataType dtype, TensorFormat format) {
   this->opt_shape = shape;
   this->min_shape = shape;
   this->max_shape = shape;
-  LOG_DEBUG("===== CONST 1");
   this->shape = shape;
   this->dtype = dtype;
   this->format = format;
-  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
-    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
-  }
   this->input_is_dynamic = false;
 }
 
@@ -178,15 +174,11 @@ Input::Input(c10::IntArrayRef shape, TensorFormat format) {
 }
 
 Input::Input(c10::IntArrayRef shape, DataType dtype, TensorFormat format) {
-  LOG_DEBUG("===== CONST 2");
   this->opt_shape = torch_tensorrt::core::util::toVec(shape);
   this->min_shape = torch_tensorrt::core::util::toVec(shape);
   this->max_shape = torch_tensorrt::core::util::toVec(shape);
   this->shape = torch_tensorrt::core::util::toVec(shape);
   this->dtype = dtype;
-  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
-    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
-  }
   this->format = format;
   this->input_is_dynamic = false;
 }
@@ -199,7 +191,6 @@ Input::Input(
   this->opt_shape = opt_shape;
   this->min_shape = min_shape;
   this->max_shape = max_shape;
-  LOG_DEBUG("===== CONST 3");
   this->shape = torch_tensorrt::core::util::toVec(
       torch_tensorrt::core::ir::Input(this->min_shape, this->opt_shape, this->max_shape).input_shape);
   this->dtype = DataType::kUnknown;
@@ -213,16 +204,12 @@ Input::Input(
     std::vector<int64_t> max_shape,
     DataType dtype,
     TensorFormat format) {
-  LOG_DEBUG("===== CONST 4");
   this->opt_shape = opt_shape;
   this->min_shape = min_shape;
   this->max_shape = max_shape;
   this->shape = torch_tensorrt::core::util::toVec(
       torch_tensorrt::core::ir::Input(this->min_shape, this->opt_shape, this->max_shape).input_shape);
   this->dtype = dtype;
-  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
-    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
-  }
   this->format = format;
   this->input_is_dynamic = true;
 }
@@ -250,9 +237,6 @@ Input::Input(
   this->shape = torch_tensorrt::core::util::toVec(
       torch_tensorrt::core::ir::Input(this->min_shape, this->opt_shape, this->max_shape).input_shape);
   this->dtype = dtype;
-  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
-    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
-  }
   this->format = format;
   this->input_is_dynamic = true;
 }
@@ -263,9 +247,6 @@ Input::Input(at::Tensor tensor) {
   this->max_shape = tensor.sizes().vec();
   this->shape = tensor.sizes().vec();
   this->dtype = tensor.scalar_type();
-  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
-    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
-  }
   TORCHTRT_ASSERT(
       tensor.is_contiguous(at::MemoryFormat::ChannelsLast) || tensor.is_contiguous(at::MemoryFormat::Contiguous),
       "Tensor does not have a supported contiguous memory format, supported formats are contiguous or channel_last");
@@ -282,9 +263,6 @@ Input::Input(at::Tensor tensor) {
 /* ==========================================*/
 
 torch_tensorrt::core::ir::Input to_internal_input(Input& i) {
-  if(i.dtype == DataType::kBool && i.format == TensorFormat::kChannelsLast){
-    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
-  }
   return torch_tensorrt::core::ir::Input(
       i.min_shape,
       i.opt_shape,

--- a/cpp/src/types.cpp
+++ b/cpp/src/types.cpp
@@ -157,9 +157,13 @@ Input::Input(std::vector<int64_t> shape, DataType dtype, TensorFormat format) {
   this->opt_shape = shape;
   this->min_shape = shape;
   this->max_shape = shape;
+  LOG_DEBUG("===== CONST 1");
   this->shape = shape;
   this->dtype = dtype;
   this->format = format;
+  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
+    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
+  }
   this->input_is_dynamic = false;
 }
 
@@ -174,11 +178,15 @@ Input::Input(c10::IntArrayRef shape, TensorFormat format) {
 }
 
 Input::Input(c10::IntArrayRef shape, DataType dtype, TensorFormat format) {
+  LOG_DEBUG("===== CONST 2");
   this->opt_shape = torch_tensorrt::core::util::toVec(shape);
   this->min_shape = torch_tensorrt::core::util::toVec(shape);
   this->max_shape = torch_tensorrt::core::util::toVec(shape);
   this->shape = torch_tensorrt::core::util::toVec(shape);
   this->dtype = dtype;
+  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
+    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
+  }
   this->format = format;
   this->input_is_dynamic = false;
 }
@@ -191,6 +199,7 @@ Input::Input(
   this->opt_shape = opt_shape;
   this->min_shape = min_shape;
   this->max_shape = max_shape;
+  LOG_DEBUG("===== CONST 3");
   this->shape = torch_tensorrt::core::util::toVec(
       torch_tensorrt::core::ir::Input(this->min_shape, this->opt_shape, this->max_shape).input_shape);
   this->dtype = DataType::kUnknown;
@@ -204,12 +213,16 @@ Input::Input(
     std::vector<int64_t> max_shape,
     DataType dtype,
     TensorFormat format) {
+  LOG_DEBUG("===== CONST 4");
   this->opt_shape = opt_shape;
   this->min_shape = min_shape;
   this->max_shape = max_shape;
   this->shape = torch_tensorrt::core::util::toVec(
       torch_tensorrt::core::ir::Input(this->min_shape, this->opt_shape, this->max_shape).input_shape);
   this->dtype = dtype;
+  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
+    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
+  }
   this->format = format;
   this->input_is_dynamic = true;
 }
@@ -237,6 +250,9 @@ Input::Input(
   this->shape = torch_tensorrt::core::util::toVec(
       torch_tensorrt::core::ir::Input(this->min_shape, this->opt_shape, this->max_shape).input_shape);
   this->dtype = dtype;
+  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
+    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
+  }
   this->format = format;
   this->input_is_dynamic = true;
 }
@@ -247,6 +263,9 @@ Input::Input(at::Tensor tensor) {
   this->max_shape = tensor.sizes().vec();
   this->shape = tensor.sizes().vec();
   this->dtype = tensor.scalar_type();
+  if(dtype == DataType::kBool && format == TensorFormat::kChannelsLast){
+    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
+  }
   TORCHTRT_ASSERT(
       tensor.is_contiguous(at::MemoryFormat::ChannelsLast) || tensor.is_contiguous(at::MemoryFormat::Contiguous),
       "Tensor does not have a supported contiguous memory format, supported formats are contiguous or channel_last");
@@ -263,6 +282,9 @@ Input::Input(at::Tensor tensor) {
 /* ==========================================*/
 
 torch_tensorrt::core::ir::Input to_internal_input(Input& i) {
+  if(i.dtype == DataType::kBool && i.format == TensorFormat::kChannelsLast){
+    TORCHTRT_THROW_ERROR("Input datatype (Bool) is not currently supported with Tensorformat NHWC (kChannelsLast)");
+  }
   return torch_tensorrt::core::ir::Input(
       i.min_shape,
       i.opt_shape,

--- a/py/setup.py
+++ b/py/setup.py
@@ -239,8 +239,6 @@ ext_modules = [
         libraries=["torchtrt"],
         include_dirs=[
             dir_path + "torch_tensorrt/csrc", dir_path + "torch_tensorrt/include",
-            dir_path + "/../bazel-TRTorch/external/tensorrt/include",
-            dir_path + "/../bazel-Torch-TensorRT-Preview/external/tensorrt/include",
             dir_path + "/../bazel-Torch-TensorRT/external/tensorrt/include", dir_path + "/../"
         ],
         extra_compile_args=[

--- a/py/setup.py
+++ b/py/setup.py
@@ -239,6 +239,7 @@ ext_modules = [
         libraries=["torchtrt"],
         include_dirs=[
             dir_path + "torch_tensorrt/csrc", dir_path + "torch_tensorrt/include",
+            dir_path + "/../bazel-TRTorch/external/tensorrt/include",
             dir_path + "/../bazel-Torch-TensorRT/external/tensorrt/include", dir_path + "/../"
         ],
         extra_compile_args=[

--- a/py/torch_tensorrt/csrc/torch_tensorrt_py.cpp
+++ b/py/torch_tensorrt/csrc/torch_tensorrt_py.cpp
@@ -185,7 +185,7 @@ PYBIND11_MODULE(_C, m) {
       .value("float16", DataType::kHalf, "16 bit floating point number")
       .value("int8", DataType::kChar, "8 bit integer number")
       .value("int32", DataType::kInt32, "32 bit integer number")
-      .value("bool", DataType::kChar, "Boolean value")
+      .value("bool", DataType::kBool, "Boolean value")
       .value("unknown", DataType::kUnknown, "Unknown data type")
       .export_values();
 


### PR DESCRIPTION
Signed-off-by: Dheeraj Peri <peri.dheeraj@gmail.com>

# Description

Use user provided dtype when we can't infer it from the graph

Fixes https://github.com/NVIDIA/Torch-TensorRT/issues/911#issuecomment-1059609092

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes