### PR TITLE
Fix roberta conversion bugs

### DIFF
--- a/core/conversion/converters/impl/cast.cpp
+++ b/core/conversion/converters/impl/cast.cpp
@@ -18,7 +18,14 @@ auto cast_registrations TORCHTRT_UNUSED =
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
                auto self = args[0].ITensorOrFreeze(ctx);
                auto output_dtype = args[1].unwrapToScalar().to<int64_t>();
-               auto trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
+               auto scalar_dtype = static_cast<at::ScalarType>(output_dtype);
+               nvinfer1::DataType trt_dtype;
+               if (scalar_dtype == at::kLong) {
+                 LOG_WARNING("Truncating aten::to output type from at::kLong to at::kInt");
+                 trt_dtype = nvinfer1::DataType::kINT32;
+               } else {
+                 trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
+               }
                auto casted_itensor = castITensor(ctx, self, trt_dtype);
                auto output = ctx->AssociateValueAndTensor(n->outputs()[0], casted_itensor);
                LOG_DEBUG("[aten::to.dtype] Output tensor shape: " << output->getDimensions());
@@ -33,9 +40,14 @@ auto cast_registrations TORCHTRT_UNUSED =
                // later shape analysis phase of fallback
                auto self = args[0].ITensorOrFreeze(ctx);
                auto output_dtype = args[2].unwrapToScalar().to<int64_t>();
-
-               auto trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
-
+               auto scalar_dtype = static_cast<at::ScalarType>(output_dtype);
+               nvinfer1::DataType trt_dtype;
+               if (scalar_dtype == at::kLong) {
+                 LOG_WARNING("Truncating aten::to output type from at::kLong to at::kInt");
+                 trt_dtype = nvinfer1::DataType::kINT32;
+               } else {
+                 trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
+               }
                auto casted_itensor = castITensor(ctx, self, trt_dtype);
                auto output = ctx->AssociateValueAndTensor(n->outputs()[0], casted_itensor);
                LOG_DEBUG("[aten::to.device] Output tensor shape: " << output->getDimensions());

--- a/core/conversion/converters/impl/cumsum.cpp
+++ b/core/conversion/converters/impl/cumsum.cpp
@@ -48,7 +48,8 @@ auto cumsum_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pat
        auto data = iterator->getOutput(0);
        auto newDims = data->getDimensions();
 
-       torch::Tensor zeroValue = at::full(util::toVec(newDims), 0, torch::kFloat32);
+       torch::Tensor zeroValue =
+           at::full(util::toVec(newDims), 0, torch_tensorrt::core::util::TRTDataTypeToScalarType(in->getType()));
        auto zeroTensor = tensor_to_const(ctx, zeroValue);
        auto runningSum = loop->addRecurrence(*zeroTensor);
        auto runningSumTensor = runningSum->getOutput(0);


### PR DESCRIPTION
# Description

Fix bugs encountered when converting a RoBERTa model. 

Fixes #963 

Specifically, it fixes three things:
- For `aten::ne.Scalar(Tensor self, Scalar other) -> (Tensor)`,  the datatype of Scalar is by default initialized to be of type float. This should be int32 in this case.
- For `aten::cumsum(Tensor self, int dim, *, int? dtype=None) -> (Tensor)`, the zeroValue which stores runningSum, is by default initialized to be of type float. This should be int32 in this case. 
- For `aten::to.dtype(Tensor self, int dtype, bool non_blocking=False, bool copy=False, int? memory_format=None) -> (Tensor)`, it could be casting tensor to `long` datatype, but this cannot be processed in our code. We simply add an entry in `get_at_trt_type_map`, where `at::kLong` would be mapped to `nvinfer1::DataType::kINT32` since tensorRT could not support `long`.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes