### PR TITLE
Allows docker to build with a specified version of the container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.
 
 ```
 # Build:
-docker build --build-arg BASE={PyTorch Base Container Version} -f docker/Dockerfile -t torch_tensorrt1.0:latest .
+DOCKER_BUILDKIT=1 docker build --build-arg BASE={PyTorch Base Container Version} -f docker/Dockerfile -t torch_tensorrt1.0:latest .
 
 # Run:
 docker run --gpus all -it \


### PR DESCRIPTION
# Description
Allows docker to build with a specified version of the container.
In other words, using `docker_buildkit` is mandatory to change the version of the base container to build docker.
So, it is grateful if the `docker/README.md` suggests using `docker_buildkit` explicitly, or adding "DOCKER_BUILDKIT=1` before the command.

This ENV is also used in [a REAME.md in pytorch](https://github.com/pytorch/pytorch/blob/master/Dockerfile#L3-L9).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- ~[ ] My code follows the style guidelines of this project (You can use the linters)~
- [x] I have performed a self-review of my own code
- ~[ ] I have commented my code, particularly in hard-to-understand areas and hacks~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added tests to verify my fix or my feature~
- ~[ ] New and existing unit tests pass locally with my changes~