### PR TITLE
fix: support dict type for input in shape analysis

### DIFF
--- a/core/partitioning/shape_analysis.cpp
+++ b/core/partitioning/shape_analysis.cpp
@@ -84,6 +84,8 @@ void getSegmentsOutputByRunning(
       jit_inputs_ivalues.push_back(ivalues_maps[input].toTuple());
     } else if (input->type()->kind() == torch::jit::TypeKind::NumberType) {
       jit_inputs_ivalues.push_back(ivalues_maps[input].toScalar());
+    } else if (input->type()->kind() == torch::jit::TypeKind::DictType) {
+      jit_inputs_ivalues.push_back(ivalues_maps[input].toGenericDict());
     } else {
       TORCHTRT_THROW_ERROR(
           "Expected to find type " << input->type()->str() << " for value " << input->debugName()


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description

Dict type was missed for input types in shape analysis. 

Fixes #981 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes