### PR TITLE
fix: Preempt torch package override via timm in nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ def download_models(session, use_host_env=False):
     if use_host_env:
         session.run_always('python', 'hub.py', env={'PYTHONPATH': PYT_PATH})
     else:
+        session.install("-r", os.path.join(TOP_DIR, "py", "requirements.txt"))
         session.run_always('python', 'hub.py')
 
 def install_torch_trt(session):


### PR DESCRIPTION
Signed-off-by: Anurag Dixit <a.dixit91@gmail.com>

# Description
timm package updates the torch version inside the nox session which becomes incompatible with the cuda version and thereby fails the hub.py script inside the CI container.

Added the installation step for py/requirements.txt so that torch package is not disturbed inside the container.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes