### PR TITLE
fix: refactor the resegmentation in ResolveNonTensorInputs

### DIFF
--- a/core/partitioning/shape_analysis.cpp
+++ b/core/partitioning/shape_analysis.cpp
@@ -86,6 +86,8 @@ void getSegmentsOutputByRunning(
       jit_inputs_ivalues.push_back(ivalues_maps[input].toScalar());
     } else if (input->type()->kind() == torch::jit::TypeKind::DictType) {
       jit_inputs_ivalues.push_back(ivalues_maps[input].toGenericDict());
+    } else if (input->type()->kind() == torch::jit::TypeKind::DeviceObjType) {
+      jit_inputs_ivalues.push_back(ivalues_maps[input].toDevice());
     } else {
       TORCHTRT_THROW_ERROR(
           "Expected to find type " << input->type()->str() << " for value " << input->debugName()


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description

There are some cases that TensorRT segments have Non-Tensor inputs after segmentation. In this case, if the nodes that produce these Non-Tensor Inputs are not supported by TensorRT, then we have to find a proper interface to re-segment this TensorRT segment again.
The previous code just naively segments the nodes one by once, which causes many issues such as what we have in #922 

Fixes #922

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes