### PR TITLE
feat: torchtrtc using atol and rtol for tolerance test

### DIFF
--- a/cpp/bin/torchtrtc/accuracy.cpp
+++ b/cpp/bin/torchtrtc/accuracy.cpp
@@ -19,8 +19,17 @@ bool check_rtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, fl
   return diff.abs().max().item<float>() <= threshold * maxValue;
 }
 
-bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold) {
-  return check_rtol(a - b, {a, b}, threshold);
+bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold, float atol, float rtol) {
+  auto a_float = a.toType(at::kFloat);
+  auto b_float = b.toType(at::kFloat);
+
+  auto diff = a_float - b_float;
+  auto result = diff.abs().max().item<float>() - (atol + rtol * b.abs().max().item<float>());
+
+  std::cout << "Max Difference: " << result << std::endl;
+  std::cout << "Acceptable Threshold: " << threshold << std::endl;
+
+  return result <= threshold;
 }
 
 } // namespace accuracy

--- a/cpp/bin/torchtrtc/accuracy.h
+++ b/cpp/bin/torchtrtc/accuracy.h
@@ -12,7 +12,7 @@ namespace torchtrtc {
 namespace accuracy {
 
 bool check_rtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, float threshold);
-bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold);
+bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold, float atol = 1e-8, float rtol = 1e-5);
 
 } // namespace accuracy
 } // namespace torchtrtc


### PR DESCRIPTION
Signed-off-by: Anurag Dixit <a.dixit91@gmail.com>

# Description
Added rtol + atol tolerance check for torchtrtc. Similar to what we have for test benchmarks.

Fixes # (issue)
#1030 
## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes